### PR TITLE
News and events detail pages, link cards to full articles/events, fix…

### DIFF
--- a/ppyc_frontend/src/App.jsx
+++ b/ppyc_frontend/src/App.jsx
@@ -22,6 +22,7 @@ const AboutPage = lazy(() => import('./pages/AboutPage'));
 const NewsPage = lazy(() => import('./pages/NewsPage'));
 const PostDetailsPage = lazy(() => import('./pages/PostDetailsPage'));
 const EventsPage = lazy(() => import('./pages/EventsPage'));
+const EventDetailsPage = lazy(() => import('./pages/EventDetailsPage'));
 const MembershipPage = lazy(() => import('./pages/MembershipPage'));
 const HeritagePage = lazy(() => import('./pages/HeritagePage'));
 const MarinaPage = lazy(() => import('./pages/MarinaPage'));
@@ -147,6 +148,7 @@ function App() {
                   <Route path="news" element={<NewsPage />} />
                   <Route path="news/:slug" element={<PostDetailsPage />} />
                   <Route path="events" element={<EventsPage />} />
+                  <Route path="events/:id" element={<EventDetailsPage />} />
                   <Route path="membership" element={<MembershipPage />} />
                   <Route path="heritage" element={<HeritagePage />} />
                   <Route path="marina" element={<MarinaPage />} />

--- a/ppyc_frontend/src/components/home/LatestNewsSection.jsx
+++ b/ppyc_frontend/src/components/home/LatestNewsSection.jsx
@@ -7,7 +7,6 @@ import { useApiCache } from '../../hooks/useApiCache';
 
 const LatestNewsSection = () => {
   const [news, setNews] = useState([]);
-  const [selectedImage, setSelectedImage] = useState(null);
 
   // Use cached API call with self-managed loading
   const { data: newsData, loading: newsLoading, error: newsError } = useApiCache(
@@ -54,24 +53,19 @@ const LatestNewsSection = () => {
         
         <div className="grid md:grid-cols-3 gap-8">
           {news.map((article) => (
-            <div key={article.id} className="bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden">
+            <Link
+              key={article.id}
+              to={article.slug ? `/news/${article.slug}` : '/news'}
+              className="block bg-white border border-gray-200 rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden group"
+            >
               {article.featured_image_url && (
-                <div 
-                  className="relative bg-gray-100 flex items-center justify-center overflow-hidden cursor-pointer group"
-                  onClick={() => setSelectedImage({ url: article.featured_image_url, title: article.title })}
-                >
+                <div className="relative bg-gray-100 flex items-center justify-center overflow-hidden">
                   <img 
                     src={article.featured_image_url} 
                     alt={article.title}
                     className="w-full h-auto object-contain max-h-[300px] transition-transform duration-200 group-hover:scale-105"
                     style={{ maxWidth: '100%', display: 'block' }}
                   />
-                  {/* Hover overlay hint */}
-                  <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-200 flex items-center justify-center">
-                    <div className="opacity-0 group-hover:opacity-100 transition-opacity bg-white bg-opacity-90 rounded-full p-2">
-                      <FontAwesomeIcon icon={ICON_NAMES.SEARCH} className="text-blue-600 text-lg" />
-                    </div>
-                  </div>
                 </div>
               )}
               <div className="p-6">
@@ -83,49 +77,13 @@ const LatestNewsSection = () => {
                     day: 'numeric' 
                   })}
                 </div>
-                <h3 className="text-xl font-bold text-slate-800 mb-3">{article.title}</h3>
+                <h3 className="text-xl font-bold text-slate-800 mb-3 group-hover:text-blue-600 transition-colors">{article.title}</h3>
                 <p className="text-gray-600 leading-relaxed line-clamp-3">{article.content?.replace(/<[^>]*>/g, '').substring(0, 150) + '...'}</p>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       </div>
-
-      {/* Image Modal/Lightbox */}
-      {selectedImage && (
-        <div 
-          className="fixed inset-0 bg-black bg-opacity-90 flex items-center justify-center z-50 p-4"
-          onClick={() => setSelectedImage(null)}
-        >
-          <div 
-            className="relative max-w-7xl max-h-[90vh] w-full"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Close Button */}
-            <button
-              onClick={() => setSelectedImage(null)}
-              className="absolute top-4 right-4 bg-white bg-opacity-90 hover:bg-opacity-100 text-gray-800 rounded-full p-3 z-10 transition-all shadow-lg"
-              aria-label="Close image"
-            >
-              <FontAwesomeIcon icon={ICON_NAMES.CLOSE} className="text-xl" />
-            </button>
-            
-            {/* Image */}
-            <div className="bg-white rounded-lg overflow-hidden shadow-2xl">
-              <img
-                src={selectedImage.url}
-                alt={selectedImage.title}
-                className="w-full h-auto max-h-[90vh] object-contain mx-auto"
-              />
-              {/* Image Title */}
-              <div className="bg-white px-6 py-4 border-t border-gray-200">
-                <h3 className="text-lg font-semibold text-gray-800">{selectedImage.title}</h3>
-                <p className="text-sm text-gray-500 mt-1">Click outside or close button to close</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </section>
   );
 };

--- a/ppyc_frontend/src/pages/EventDetailsPage.jsx
+++ b/ppyc_frontend/src/pages/EventDetailsPage.jsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ICON_NAMES } from '../config/fontawesome';
+import SEOHelmet from '../components/SEOHelmet';
+import { eventsAPI } from '../services/api';
+import { useApiCache } from '../hooks/useApiCache';
+import { sanitizeHtml } from '../utils/htmlUtils';
+
+const EventDetailsPage = () => {
+  const { id } = useParams();
+  const { data: response, loading, error } = useApiCache(
+    () => eventsAPI.getById(id),
+    `events-${id}`,
+    {
+      ttl: 10 * 60 * 1000,
+      enabled: !!id,
+      dependencies: [id],
+    }
+  );
+
+  const event = response?.data;
+
+  const formatDate = (dateString) => {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  const formatTime = (dateString) => {
+    if (!dateString) return '';
+    return new Date(dateString).toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <div className="w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-4 animate-spin">
+            <FontAwesomeIcon icon={ICON_NAMES.LOADING} className="text-white text-xl" />
+          </div>
+          <p className="text-slate-600">Loading event...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !event) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h1 className="text-4xl font-bold text-slate-900 mb-4">Event Not Found</h1>
+          <p className="text-slate-600 mb-8">
+            The event you're looking for doesn't exist or has been removed.
+          </p>
+          <div className="space-x-4">
+            <Link to="/events" className="btn-primary">
+              Back to Events
+            </Link>
+            <Link to="/" className="btn-secondary">
+              Return Home
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <SEOHelmet
+        title={`${event.title} - Events | Pleasant Park Yacht Club`}
+        description={event.description ? sanitizeHtml(event.description).replace(/<[^>]*>/g, '').slice(0, 160) : `Join us for ${event.title} at Pleasant Park Yacht Club.`}
+        type="article"
+      />
+
+      {/* Breadcrumb */}
+      <nav className="bg-white border-b border-slate-200 py-4">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center space-x-2 text-sm text-slate-600">
+            <Link to="/" className="hover:text-blue-600 transition-colors">
+              Home
+            </Link>
+            <span>›</span>
+            <Link to="/events" className="hover:text-blue-600 transition-colors">
+              Events
+            </Link>
+            <span>›</span>
+            <span className="text-slate-900 font-medium">{event.title}</span>
+          </div>
+        </div>
+      </nav>
+
+      <article className="py-12">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="bg-white rounded-lg shadow-lg overflow-hidden">
+            {event.image_url && (
+              <div className="w-full h-80 sm:h-96 overflow-hidden">
+                <img
+                  src={event.image_url}
+                  alt={event.title}
+                  className="w-full h-full object-cover"
+                />
+              </div>
+            )}
+
+            <div className="p-8 md:p-12">
+              <div className="flex flex-wrap items-center gap-4 text-sm text-slate-500 mb-6 pb-6 border-b border-slate-200">
+                <span className="flex items-center gap-2">
+                  <FontAwesomeIcon icon={ICON_NAMES.CALENDAR_DAY} />
+                  {formatDate(event.start_time)}
+                </span>
+                {(event.start_time || event.end_time) && (
+                  <span className="flex items-center gap-2">
+                    <FontAwesomeIcon icon={ICON_NAMES.CLOCK} />
+                    {formatTime(event.start_time)}
+                    {event.end_time && ` – ${formatTime(event.end_time)}`}
+                  </span>
+                )}
+                {event.location && (
+                  <span className="flex items-center gap-2">
+                    <FontAwesomeIcon icon={ICON_NAMES.LOCATION} />
+                    {event.location}
+                  </span>
+                )}
+              </div>
+
+              <h1 className="text-3xl md:text-4xl font-bold text-slate-900 mb-6">
+                {event.title}
+              </h1>
+
+              {event.description && (
+                <div
+                  className="prose prose-lg max-w-none text-slate-700"
+                  dangerouslySetInnerHTML={{ __html: sanitizeHtml(event.description) }}
+                />
+              )}
+            </div>
+          </div>
+
+          <div className="mt-12 flex justify-between items-center">
+            <Link
+              to="/events"
+              className="inline-flex items-center text-blue-600 hover:text-blue-700 font-medium transition-colors"
+            >
+              <FontAwesomeIcon icon={ICON_NAMES.CHEVRON_LEFT} className="mr-2 w-4 h-4" />
+              Back to All Events
+            </Link>
+            <Link to="/news" className="text-slate-500 hover:text-blue-600 transition-colors text-sm">
+              View Club News
+            </Link>
+          </div>
+        </div>
+      </article>
+    </div>
+  );
+};
+
+export default EventDetailsPage;

--- a/ppyc_frontend/src/pages/EventsPage.jsx
+++ b/ppyc_frontend/src/pages/EventsPage.jsx
@@ -12,7 +12,7 @@ import { useApiCache } from '../hooks/useApiCache';
 const EventsPage = () => {
   const [events, setEvents] = useState([]);
   const [error, setError] = useState(null);
-  const [selectedImage, setSelectedImage] = useState(null);
+  const [selectedImage, setSelectedImage] = useState(null); // { url, title, description? }
 
   // Use cached API call with loading state tracking
   const { data: eventsData, loading: eventsLoading, error: eventsError } = useApiCache(
@@ -93,9 +93,11 @@ const EventsPage = () => {
     return event >= startOfWeek && event <= endOfWeek;
   };
 
-  // Handle image click to open modal
-  const handleImageClick = (imageUrl, eventTitle) => {
-    setSelectedImage({ url: imageUrl, title: eventTitle });
+  // Handle image click to open modal (stops propagation so card link doesn't fire)
+  const handleImageClick = (e, imageUrl, eventTitle, eventDescription) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setSelectedImage({ url: imageUrl, title: eventTitle, description: eventDescription });
   };
 
   // Close modal
@@ -164,15 +166,16 @@ const EventsPage = () => {
                   {/* Events Grid */}
                   <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
                     {monthEvents.map((event) => (
-                      <div 
-                        key={event.id} 
-                        className="bg-white rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden border border-gray-100"
+                      <Link
+                        key={event.id}
+                        to={`/events/${event.id}`}
+                        className="block bg-white rounded-xl shadow-lg hover:shadow-xl transition-shadow duration-300 overflow-hidden border border-gray-100 group"
                       >
                         {/* Event Image */}
                         {event.image_url && (
                           <div 
-                            className="relative bg-gray-100 flex items-center justify-center overflow-hidden cursor-pointer group"
-                            onClick={() => handleImageClick(event.image_url, event.title)}
+                            className="relative bg-gray-100 flex items-center justify-center overflow-hidden cursor-pointer"
+                            onClick={(e) => handleImageClick(e, event.image_url, event.title, event.description)}
                           >
                             <img 
                               src={event.image_url} 
@@ -214,12 +217,12 @@ const EventsPage = () => {
                             })}
                           </div>
 
-                          <h3 className="text-xl font-bold text-slate-800 mb-3">{event.title}</h3>
+                          <h3 className="text-xl font-bold text-slate-800 mb-3 group-hover:text-blue-600 transition-colors">{event.title}</h3>
                           
                           {/* Render HTML content properly */}
                           {event.description && (
                             <div 
-                              className="text-gray-600 leading-relaxed mb-4 prose-event"
+                              className="text-gray-600 leading-relaxed mb-4 prose-event line-clamp-3"
                               dangerouslySetInnerHTML={{ __html: sanitizeHtml(event.description) }}
                             />
                           )}
@@ -231,7 +234,7 @@ const EventsPage = () => {
                             </div>
                           )}
                         </div>
-                      </div>
+                      </Link>
                     ))}
                   </div>
                 </div>
@@ -346,36 +349,44 @@ const EventsPage = () => {
         </div>
       </section>
 
-      {/* Image Modal/Lightbox */}
+      {/* Image Modal/Lightbox - centered with top padding, image + copy visible */}
       {selectedImage && (
         <div 
-          className="fixed inset-0 bg-black bg-opacity-90 flex items-center justify-center z-50 p-4"
+          className="fixed inset-0 bg-black bg-opacity-90 z-50 flex items-center justify-center pt-12 pb-12 px-4 overflow-y-auto"
           onClick={handleCloseModal}
         >
           <div 
-            className="relative max-w-7xl max-h-[90vh] w-full"
+            className="relative w-full max-w-4xl flex flex-col items-center my-auto"
             onClick={(e) => e.stopPropagation()}
           >
             {/* Close Button */}
             <button
               onClick={handleCloseModal}
-              className="absolute top-4 right-4 bg-white bg-opacity-90 hover:bg-opacity-100 text-gray-800 rounded-full p-3 z-10 transition-all shadow-lg"
+              className="absolute -top-2 right-0 sm:right-4 bg-white bg-opacity-90 hover:bg-opacity-100 text-gray-800 rounded-full p-3 z-10 transition-all shadow-lg"
               aria-label="Close image"
             >
               <FontAwesomeIcon icon={ICON_NAMES.CLOSE} className="text-xl" />
             </button>
             
-            {/* Image */}
-            <div className="bg-white rounded-lg overflow-hidden shadow-2xl">
-              <img
-                src={selectedImage.url}
-                alt={selectedImage.title}
-                className="w-full h-auto max-h-[90vh] object-contain mx-auto"
-              />
-              {/* Image Title */}
-              <div className="bg-white px-6 py-4 border-t border-gray-200">
+            <div className="bg-white rounded-lg overflow-hidden shadow-2xl w-full flex flex-col max-h-[85vh]">
+              {/* Image - constrained so caption stays in view */}
+              <div className="flex-shrink-0 overflow-hidden">
+                <img
+                  src={selectedImage.url}
+                  alt={selectedImage.title}
+                  className="w-full h-auto max-h-[60vh] object-contain mx-auto block"
+                />
+              </div>
+              {/* Caption / Copy - always visible below image */}
+              <div className="flex-shrink-0 bg-white px-6 py-4 border-t border-gray-200">
                 <h3 className="text-lg font-semibold text-gray-800">{selectedImage.title}</h3>
-                <p className="text-sm text-gray-500 mt-1">Click outside or press ESC to close</p>
+                {selectedImage.description && (
+                  <div 
+                    className="text-gray-600 text-sm mt-2 prose-event max-h-32 overflow-y-auto"
+                    dangerouslySetInnerHTML={{ __html: sanitizeHtml(selectedImage.description) }}
+                  />
+                )}
+                <p className="text-gray-400 text-xs mt-2">Click outside or close button to close</p>
               </div>
             </div>
           </div>

--- a/ppyc_frontend/src/pages/NewsPage.jsx
+++ b/ppyc_frontend/src/pages/NewsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ICON_NAMES } from '../config/fontawesome';
 import SEOHelmet from '../components/SEOHelmet';
@@ -28,7 +29,6 @@ const NewsPage = () => {
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [selectedImage, setSelectedImage] = useState(null);
 
   useEffect(() => {
     const fetchPosts = async () => {
@@ -89,78 +89,34 @@ const NewsPage = () => {
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             {posts.map((post) => (
-              <div
+              <Link
                 key={post.id}
-                className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300"
+                to={post.slug ? `/news/${post.slug}` : '#'}
+                className="block bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 group"
               >
                 {post.featured_image_url && (
-                  <div 
-                    className="relative bg-gray-100 flex items-center justify-center overflow-hidden cursor-pointer group"
-                    onClick={() => setSelectedImage({ url: post.featured_image_url, title: post.title })}
-                  >
+                  <div className="relative bg-gray-100 flex items-center justify-center overflow-hidden">
                     <img
                       src={post.featured_image_url}
                       alt={post.title}
                       className="w-full h-auto object-contain max-h-[300px] transition-transform duration-200 group-hover:scale-105"
                       style={{ maxWidth: '100%', display: 'block' }}
                     />
-                    {/* Hover overlay hint */}
-                    <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-10 transition-all duration-200 flex items-center justify-center">
-                      <div className="opacity-0 group-hover:opacity-100 transition-opacity bg-white bg-opacity-90 rounded-full p-2">
-                        <FontAwesomeIcon icon={ICON_NAMES.SEARCH} className="text-blue-600 text-lg" />
-                      </div>
-                    </div>
                   </div>
                 )}
                 <div className="p-6">
-                  <h2 className="text-xl font-semibold mb-2 text-gray-900">{post.title}</h2>
+                  <h2 className="text-xl font-semibold mb-2 text-gray-900 group-hover:text-blue-600 transition-colors">{post.title}</h2>
                   <p className="text-gray-600 mb-4">{generateExcerpt(post.content)}</p>
                   <div className="flex items-center text-sm text-gray-500">
                     <FontAwesomeIcon icon={ICON_NAMES.CALENDAR} className="mr-2" />
                     <span>{formatDate(post.published_at)}</span>
                   </div>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         )}
       </div>
-
-      {/* Image Modal/Lightbox */}
-      {selectedImage && (
-        <div 
-          className="fixed inset-0 bg-black bg-opacity-90 flex items-center justify-center z-50 p-4"
-          onClick={() => setSelectedImage(null)}
-        >
-          <div 
-            className="relative max-w-7xl max-h-[90vh] w-full"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Close Button */}
-            <button
-              onClick={() => setSelectedImage(null)}
-              className="absolute top-4 right-4 bg-white bg-opacity-90 hover:bg-opacity-100 text-gray-800 rounded-full p-3 z-10 transition-all shadow-lg"
-              aria-label="Close image"
-            >
-              <FontAwesomeIcon icon={ICON_NAMES.CLOSE} className="text-xl" />
-            </button>
-            
-            {/* Image */}
-            <div className="bg-white rounded-lg overflow-hidden shadow-2xl">
-              <img
-                src={selectedImage.url}
-                alt={selectedImage.title}
-                className="w-full h-auto max-h-[90vh] object-contain mx-auto"
-              />
-              {/* Image Title */}
-              <div className="bg-white px-6 py-4 border-t border-gray-200">
-                <h3 className="text-lg font-semibold text-gray-800">{selectedImage.title}</h3>
-                <p className="text-sm text-gray-500 mt-1">Click outside or close button to close</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
… image lightbox

- News: cards on /news and home Latest News link to full article at /news/:slug (SEO-friendly)
- Events: add EventDetailsPage at /events/:id; event cards link to detail page
- Remove news image lightbox; keep events image lightbox with caption + top padding
- Lightbox: show title and description/copy, center content with pt-12/pb-12, constrain image height so caption stays visible

Made-with: Cursor