### PR TITLE
Update marina terminology to club across user-facing content.

### DIFF
--- a/ppyc_frontend/public/robots.txt
+++ b/ppyc_frontend/public/robots.txt
@@ -10,6 +10,7 @@ Allow: /about
 Allow: /heritage
 Allow: /events
 Allow: /news
+Allow: /club
 Allow: /marina
 Allow: /membership
 Allow: /pages/

--- a/ppyc_frontend/public/sitemap.xml
+++ b/ppyc_frontend/public/sitemap.xml
@@ -11,7 +11,7 @@
     <image:image>
       <image:loc>/ppyc-logo.png</image:loc>
       <image:title>Pleasant Park Yacht Club</image:title>
-      <image:caption>Pleasant Park Yacht Club logo and marina</image:caption>
+      <image:caption>Pleasant Park Yacht Club logo and clubhouse</image:caption>
     </image:image>
   </url>
 
@@ -47,7 +47,15 @@
     <priority>0.8</priority>
   </url>
 
-  <!-- Marina Services Page -->
+  <!-- Club Services Page -->
+  <url>
+    <loc>/club</loc>
+    <lastmod>2025-01-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- Legacy Marina Services URL -->
   <url>
     <loc>/marina</loc>
     <lastmod>2025-01-12</lastmod>

--- a/ppyc_frontend/src/App.jsx
+++ b/ppyc_frontend/src/App.jsx
@@ -152,6 +152,7 @@ function App() {
                   <Route path="events/:id" element={<EventDetailsPage />} />
                   <Route path="membership" element={<MembershipPage />} />
                   <Route path="heritage" element={<HeritagePage />} />
+                  <Route path="club" element={<MarinaPage />} />
                   <Route path="marina" element={<MarinaPage />} />
                   <Route path="pages/:slug" element={<StaticPage />} />
                 </Route>

--- a/ppyc_frontend/src/components/Footer.jsx
+++ b/ppyc_frontend/src/components/Footer.jsx
@@ -52,7 +52,7 @@ function Footer() {
             </div>
             <p className="text-slate-300 mb-6 max-w-md">
               Join our prestigious yacht club and experience the finest in boating, 
-              marina services, and maritime community on the beautiful waters of Boston Harbor.
+              club services, and maritime community on the beautiful waters of Boston Harbor.
             </p>
             
             {/* Social Links - Only show if URLs are configured */}
@@ -79,8 +79,8 @@ function Footer() {
                 </Link>
               </li>
               <li>
-                <Link to="/marina" className="text-slate-300 hover:text-white transition-colors">
-                  Marina Services
+                <Link to="/club" className="text-slate-300 hover:text-white transition-colors">
+                  Club Services
                 </Link>
               </li>
               <li>

--- a/ppyc_frontend/src/components/Navigation.jsx
+++ b/ppyc_frontend/src/components/Navigation.jsx
@@ -41,7 +41,7 @@ function Navigation() {
     { name: 'About', path: '/about', icon: ICON_NAMES.INFO },
     { name: 'News', path: '/news', icon: ICON_NAMES.NEWS },
     { name: 'Events', path: '/events', icon: ICON_NAMES.CALENDAR },
-    { name: 'Marina', path: '/marina', icon: ICON_NAMES.ANCHOR },
+    { name: 'Club', path: '/club', icon: ICON_NAMES.ANCHOR },
     { name: 'Heritage', path: '/heritage', icon: ICON_NAMES.SHIP },
     { name: 'Membership', path: '/membership', icon: ICON_NAMES.USERS },
   ];

--- a/ppyc_frontend/src/components/SEOHelmet.jsx
+++ b/ppyc_frontend/src/components/SEOHelmet.jsx
@@ -6,18 +6,18 @@ function SEOHelmet({ title, description, image, keywords, type = 'website' }) {
 
   // Default SEO values
   const defaultSEO = {
-    title: 'Pleasant Park Yacht Club - Premier Boston Marina & Sailing Community Est. 1910',
-    description: 'Pleasant Park Yacht Club, established 1910, offers premier marina services, sailing instruction, yacht club dining, and maritime community in Boston. Join our sailing legacy!',
+    title: 'Pleasant Park Yacht Club - Premier Boston Yacht Club & Sailing Community Est. 1910',
+    description: 'Pleasant Park Yacht Club, established 1910, offers premier club services, sailing instruction, yacht club dining, and maritime community in Boston. Join our sailing legacy!',
     image: 'https://srv894370.hstgr.cloud/assets/images/ppyc-images/ppyc-hero.png',
-    keywords: 'yacht club, marina, Boston sailing, boat slips, sailing instruction, waterfront dining, maritime community, yacht services, boat storage, Boston harbor'
+    keywords: 'yacht club, Boston sailing, boat slips, sailing instruction, waterfront dining, maritime community, yacht services, boat storage, Boston harbor'
   };
 
   // Page-specific SEO data
   const pageSEO = {
     '/': {
-      title: 'Pleasant Park Yacht Club - Premier Boston Marina & Sailing Community Est. 1910',
-      description: 'Discover Pleasant Park Yacht Club, Boston\'s premier marina community since 1910. Full-service marina, sailing instruction, waterfront dining, and maritime heritage.',
-      keywords: 'PPYC, yacht club Boston, marina services, sailing lessons, boat slips Boston, waterfront dining'
+      title: 'Pleasant Park Yacht Club - Premier Boston Yacht Club & Sailing Community Est. 1910',
+      description: 'Discover Pleasant Park Yacht Club, Boston\'s premier yacht club community since 1910. Full-service club amenities, sailing instruction, waterfront dining, and maritime heritage.',
+      keywords: 'PPYC, yacht club Boston, club services, sailing lessons, boat slips Boston, waterfront dining'
     },
     '/about': {
       title: 'About PPYC - Boston\'s Premier Yacht Club Since 1910',
@@ -31,23 +31,28 @@ function SEOHelmet({ title, description, image, keywords, type = 'website' }) {
     },
     '/events': {
       title: 'Events & Activities - Pleasant Park Yacht Club',
-      description: 'Join PPYC for exciting yacht club events, regattas, social gatherings, and sailing activities. View our calendar of upcoming marina and clubhouse events.',
-      keywords: 'yacht club events, sailing regattas, marina activities, boat club social events, PPYC calendar'
+      description: 'Join PPYC for exciting yacht club events, regattas, social gatherings, and sailing activities. View our calendar of upcoming club and clubhouse events.',
+      keywords: 'yacht club events, sailing regattas, club activities, boat club social events, PPYC calendar'
     },
     '/news': {
       title: 'News & Updates - Pleasant Park Yacht Club Boston',
-      description: 'Stay updated with the latest news, announcements, and stories from Pleasant Park Yacht Club. Marina updates, sailing news, and community highlights.',
-      keywords: 'yacht club news, marina updates, sailing announcements, PPYC stories, boat club updates'
+      description: 'Stay updated with the latest news, announcements, and stories from Pleasant Park Yacht Club. Club updates, sailing news, and community highlights.',
+      keywords: 'yacht club news, club updates, sailing announcements, PPYC stories, boat club updates'
+    },
+    '/club': {
+      title: 'Club Services - Full Service Boston Harbor Yacht Club | PPYC',
+      description: 'Complete club services at Pleasant Park Yacht Club. 200 boat slips, fuel dock, maintenance, winter storage, and professional harbor services in Boston.',
+      keywords: 'Boston yacht club, boat slips, club services, fuel dock, boat storage, harbor services, yacht services'
     },
     '/marina': {
-      title: 'Marina Services - Full Service Boston Harbor Marina | PPYC',
-      description: 'Complete marina services at Pleasant Park Yacht Club. 200 boat slips, fuel dock, maintenance, winter storage, and professional harbor services in Boston.',
-      keywords: 'Boston marina, boat slips, marina services, fuel dock, boat storage, harbor services, yacht services'
+      title: 'Club Services - Full Service Boston Harbor Yacht Club | PPYC',
+      description: 'Complete club services at Pleasant Park Yacht Club. 200 boat slips, fuel dock, maintenance, winter storage, and professional harbor services in Boston.',
+      keywords: 'Boston yacht club, boat slips, club services, fuel dock, boat storage, harbor services, yacht services'
     },
     '/membership': {
       title: 'Membership - Join Pleasant Park Yacht Club Boston',
-      description: 'Become a member of Boston\'s premier yacht club. Explore membership benefits, marina privileges, dining access, and sailing community at Pleasant Park Yacht Club.',
-      keywords: 'yacht club membership, join boat club Boston, marina membership, sailing club membership, PPYC member benefits'
+      description: 'Become a member of Boston\'s premier yacht club. Explore membership benefits, club privileges, dining access, and sailing community at Pleasant Park Yacht Club.',
+      keywords: 'yacht club membership, join boat club Boston, club membership, sailing club membership, PPYC member benefits'
     }
   };
 

--- a/ppyc_frontend/src/components/admin/MediaLibrary.jsx
+++ b/ppyc_frontend/src/components/admin/MediaLibrary.jsx
@@ -737,7 +737,7 @@ const MediaLibrary = () => {
               >
                 <option value="ppyc/uploads">ppyc/uploads</option>
                 <option value="ppyc/events">ppyc/events</option>
-                <option value="ppyc/marina">ppyc/marina</option>
+                <option value="ppyc/club">ppyc/club</option>
                 <option value="ppyc/historical">ppyc/historical</option>
                 <option value="ppyc/facilities">ppyc/facilities</option>
                 <option value="ppyc/activities">ppyc/activities</option>

--- a/ppyc_frontend/src/components/admin/SettingsPanel.jsx
+++ b/ppyc_frontend/src/components/admin/SettingsPanel.jsx
@@ -398,7 +398,7 @@ const SettingsPanel = () => {
                     value={settings.general.address || ''}
                     onChange={(e) => handleInputChange('general', 'address', e.target.value)}
                     className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900 placeholder-gray-500"
-                    placeholder="123 Marina Drive, Boston, MA 02101"
+                    placeholder="123 Yacht Club Drive, Boston, MA 02101"
                   />
                 </div>
               </div>

--- a/ppyc_frontend/src/pages/AboutPage.jsx
+++ b/ppyc_frontend/src/pages/AboutPage.jsx
@@ -115,8 +115,8 @@ function AboutPage() {
                   1978
                 </div>
                 <div>
-                  <h3 className="text-xl font-bold text-slate-800 mb-2">Marina Expansion</h3>
-                  <p className="text-gray-700">Major marina renovations added 100 additional slips and modern amenities, establishing PPYC as a premier boating destination.</p>
+                  <h3 className="text-xl font-bold text-slate-800 mb-2">Club Expansion</h3>
+                  <p className="text-gray-700">Major club waterfront renovations added 100 additional slips and modern amenities, establishing PPYC as a premier boating destination.</p>
                 </div>
               </div>
             </div>
@@ -206,16 +206,16 @@ function AboutPage() {
             <div className="bg-white rounded-lg shadow-lg overflow-hidden">
               <img 
                 src={YACHT_CLUB_ASSETS.gallery.marina[1]}
-                alt="Marina facilities"
+                alt="Club facilities"
                 className="w-full h-48 object-cover"
               />
               <div className="p-6">
                 <div className="flex items-center gap-3 mb-3">
                   <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} className="text-xl text-blue-600" />
-                  <h3 className="text-xl font-bold text-slate-800">Full-Service Marina</h3>
+                  <h3 className="text-xl font-bold text-slate-800">Full-Service Club</h3>
                 </div>
                 <p className="text-gray-700">
-                  Enjoy our very well-kept marina, offering 103 slips for vessels up to 50 feet, each equipped with electricity and water.
+                  Enjoy our very well-kept club docks, offering 103 slips for vessels up to 50 feet, each equipped with electricity and water.
                 </p>
               </div>
             </div>

--- a/ppyc_frontend/src/pages/EventsPage.jsx
+++ b/ppyc_frontend/src/pages/EventsPage.jsx
@@ -278,12 +278,12 @@ const EventsPage = () => {
         </div>
       </section>
 
-      {/* Marina Activities Showcase */}
+      {/* Club Activities Showcase */}
       <section className="py-16 bg-gray-50">
         <div className="max-w-6xl mx-auto px-6">
           <div className="text-center mb-12">
             <FontAwesomeIcon icon={ICON_NAMES.SHIP} className="text-4xl text-blue-600 mb-4" />
-            <h2 className="text-3xl font-bold text-slate-800 mb-4">Life at the Marina</h2>
+            <h2 className="text-3xl font-bold text-slate-800 mb-4">Life at the Club</h2>
             <div className="w-16 h-1 bg-blue-600 mx-auto mb-6"></div>
             <p className="text-gray-600 max-w-2xl mx-auto">
               Whether you're joining us for a Sister Yacht Club Invasion or simply unwinding on the water, Pleasant Park Yacht Club delivers endless opportunities for fun and relaxation.
@@ -309,12 +309,12 @@ const EventsPage = () => {
               <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow">
                 <img 
                   src="/assets/images/ppyc-images/float2.jpg" 
-                  alt="Marina Facilities" 
+                  alt="Club Facilities" 
                   className="w-full h-32 object-cover"
                 />
                 <div className="p-4">
                   <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} className="text-blue-600 text-xl mb-2" />
-                  <h3 className="font-semibold text-slate-800 text-sm">Marina Services</h3>
+                  <h3 className="font-semibold text-slate-800 text-sm">Club Services</h3>
                 </div>
               </div>
             </div>

--- a/ppyc_frontend/src/pages/HeritagePage.jsx
+++ b/ppyc_frontend/src/pages/HeritagePage.jsx
@@ -155,7 +155,7 @@ const HeritagePage = () => {
                 alt="Historic PPYC clubhouse" 
                 className="w-full rounded-lg shadow-lg"
               />
-              <p className="text-sm text-gray-500 text-center mt-2 italic">The original clubhouse and marina</p>
+              <p className="text-sm text-gray-500 text-center mt-2 italic">The original clubhouse and club docks</p>
             </div>
           </div>
         </section>
@@ -294,9 +294,9 @@ const HeritagePage = () => {
                 <div className="w-12 h-12 bg-blue-600 rounded-full flex items-center justify-center mx-auto mb-4">
                   <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} className="text-white text-xl" />
                 </div>
-                <h3 className="text-lg font-bold text-slate-800 mb-3 text-center">1967-1971: Marina Development</h3>
+                <h3 className="text-lg font-bold text-slate-800 mb-3 text-center">1967-1971: Club Development</h3>
                 <p className="text-gray-700 text-center">
-                  Under Commodores Al Marley Jr. and Pat Marino, the modern marina took shape with new floats and expanded facilities.
+                  Under Commodores Al Marley Jr. and Pat Marino, the modern club waterfront took shape with new floats and expanded facilities.
                 </p>
               </div>
               
@@ -355,7 +355,7 @@ const HeritagePage = () => {
               </div>
               <h3 className="text-xl font-bold text-slate-800 mb-3">Maritime Excellence</h3>
               <p className="text-gray-600">
-                From the Radio Class innovation to modern marina development, always at the forefront of boating.
+                From the Radio Class innovation to modern club development, always at the forefront of boating.
               </p>
             </div>
             

--- a/ppyc_frontend/src/pages/MarinaPage.jsx
+++ b/ppyc_frontend/src/pages/MarinaPage.jsx
@@ -10,8 +10,8 @@ const MarinaPage = () => {
   return (
     <div className="min-h-screen bg-white">
       <SEOHelmet
-        title="Marina - Pleasant Park Yacht Club"
-        description="Explore our state-of-the-art marina facilities at Pleasant Park Yacht Club. Safe harbor, modern amenities, and exceptional service."
+        title="Club - Pleasant Park Yacht Club"
+        description="Explore our state-of-the-art club facilities at Pleasant Park Yacht Club. Safe harbor, modern amenities, and exceptional service."
       />
 
       {/* Hero Section with Video Background */}
@@ -28,7 +28,7 @@ const MarinaPage = () => {
         <div className="relative z-10 flex items-center justify-center h-full text-center px-4">
           <div>
             <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-4">
-              Our Marina
+              Our Club
             </h1>
             <p className="text-xl text-white max-w-2xl mx-auto">
               Experience world-class facilities and services in our protected harbor.
@@ -43,7 +43,7 @@ const MarinaPage = () => {
         <section className="mb-20">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold text-slate-800 mb-4">
-              Marina Services & Amenities
+              Club Services & Amenities
             </h2>
             <div className="w-20 h-1 bg-blue-600 mx-auto mb-6"></div>
             <p className="text-xl text-slate-600 max-w-3xl mx-auto leading-relaxed">
@@ -63,7 +63,7 @@ const MarinaPage = () => {
                     <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} className="text-blue-600 text-lg" />
                   </div>
                   <div>
-                    <h4 className="text-lg font-semibold text-slate-800 mb-2">Summer Marina Slip Assignments</h4>
+                    <h4 className="text-lg font-semibold text-slate-800 mb-2">Summer Club Slip Assignments</h4>
                     <p className="text-slate-600">Secure seasonal moorage for members throughout the boating season</p>
                   </div>
                 </div>
@@ -73,7 +73,7 @@ const MarinaPage = () => {
                     <FontAwesomeIcon icon={ICON_NAMES.CALENDAR} className="text-blue-600 text-lg" />
                   </div>
                   <div>
-                    <h4 className="text-lg font-semibold text-slate-800 mb-2">Daily and Short Term Marina Slip Rentals</h4>
+                    <h4 className="text-lg font-semibold text-slate-800 mb-2">Daily and Short Term Club Slip Rentals</h4>
                     <p className="text-slate-600">Flexible rental options for visiting boaters and temporary needs</p>
                   </div>
                 </div>
@@ -154,13 +154,13 @@ const MarinaPage = () => {
           </div>
         </section>
 
-        {/* Official Marina Layout */}
+        {/* Official Club Layout */}
         <section className="mb-20">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-slate-800 mb-4">Official Marina Layout</h2>
+            <h2 className="text-3xl font-bold text-slate-800 mb-4">Official Club Layout</h2>
             <div className="w-16 h-1 bg-blue-600 mx-auto mb-6"></div>
             <p className="text-slate-600 max-w-2xl mx-auto">
-              Our detailed marina layout shows slip assignments, facilities, and navigation paths for easy dock access.
+              Our detailed club layout shows slip assignments, facilities, and navigation paths for easy dock access.
             </p>
           </div>
 
@@ -168,11 +168,11 @@ const MarinaPage = () => {
             <div className="text-center mb-8">
               <img 
                 src="/assets/images/ppyc-images/ppyc-marina-layout.png" 
-                alt="PPYC Marina Layout Diagram" 
+                alt="PPYC Club Layout Diagram" 
                 className="w-full max-w-4xl mx-auto rounded-xl shadow-lg border border-gray-200"
               />
               <p className="text-sm text-gray-500 text-center mt-4 italic">
-                Official PPYC Marina Layout - Slip assignments, facilities, and navigation paths
+                Official PPYC Club Layout - Slip assignments, facilities, and navigation paths
               </p>
             </div>
             
@@ -193,10 +193,10 @@ const MarinaPage = () => {
           </div>
         </section>
 
-        {/* Marina Facilities */}
+        {/* Club Facilities */}
         <section className="mb-20">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-slate-800 mb-4">Marina Facilities</h2>
+            <h2 className="text-3xl font-bold text-slate-800 mb-4">Club Facilities</h2>
             <div className="w-16 h-1 bg-blue-600 mx-auto"></div>
           </div>
 
@@ -204,15 +204,15 @@ const MarinaPage = () => {
             <div>
               <img 
                 src="/assets/images/ppyc-images/dockal.jpg" 
-                alt="PPYC Marina Dock Facilities" 
+                alt="PPYC Club Dock Facilities" 
                 className="w-full rounded-xl shadow-lg"
               />
               <p className="text-sm text-gray-500 text-center mt-3 italic">
-                Modern floating dock systems and marina infrastructure
+                Modern floating dock systems and club infrastructure
               </p>
             </div>
             <div>
-              <h3 className="text-2xl font-bold text-slate-800 mb-6">Modern Marina Amenities</h3>
+              <h3 className="text-2xl font-bold text-slate-800 mb-6">Modern Club Amenities</h3>
               <div className="space-y-4">
                 <div className="flex items-center gap-3">
                   <FontAwesomeIcon icon={ICON_NAMES.CHECK_CIRCLE} className="text-green-600 text-lg" />
@@ -232,26 +232,26 @@ const MarinaPage = () => {
                 </div>
                 <div className="flex items-center gap-3">
                   <FontAwesomeIcon icon={ICON_NAMES.CHECK_CIRCLE} className="text-green-600 text-lg" />
-                  <span className="text-slate-700">Very well kept marina</span>
+                  <span className="text-slate-700">Very well kept club</span>
                 </div>
               </div>
             </div>
           </div>
         </section>
 
-        {/* Marina Life Gallery */}
+        {/* Club Life Gallery */}
         <section className="mb-20">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-slate-800 mb-4">Life at the Marina</h2>
+            <h2 className="text-3xl font-bold text-slate-800 mb-4">Life at the Club</h2>
             <div className="w-16 h-1 bg-blue-600 mx-auto mb-6"></div>
-            <p className="text-slate-600">Experience the vibrant marina community at Pleasant Park Yacht Club</p>
+            <p className="text-slate-600">Experience the vibrant club community at Pleasant Park Yacht Club</p>
           </div>
           
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
             <div className="group">
               <img 
                 src="/assets/images/ppyc-images/float.jpg" 
-                alt="Marina floating docks" 
+                alt="Club floating docks" 
                 className="w-full h-32 object-cover rounded-lg shadow-md group-hover:shadow-xl transition-all duration-300 group-hover:scale-105"
               />
               <p className="text-sm text-center text-slate-600 mt-2">Floating Dock System</p>
@@ -259,7 +259,7 @@ const MarinaPage = () => {
             <div className="group">
               <img 
                 src="/assets/images/ppyc-images/dinghy.jpg" 
-                alt="Boats at the marina" 
+                alt="Boats at the club" 
                 className="w-full h-32 object-cover rounded-lg shadow-md group-hover:shadow-xl transition-all duration-300 group-hover:scale-105"
               />
               <p className="text-sm text-center text-slate-600 mt-2">Boat Moorage</p>
@@ -275,7 +275,7 @@ const MarinaPage = () => {
             <div className="group">
               <img 
                 src="/assets/images/ppyc-images/sunset.jpg" 
-                alt="Marina sunset views" 
+                alt="Club sunset views" 
                 className="w-full h-32 object-cover rounded-lg shadow-md group-hover:shadow-xl transition-all duration-300 group-hover:scale-105"
               />
               <p className="text-sm text-center text-slate-600 mt-2">Sunset Views</p>
@@ -356,11 +356,11 @@ const MarinaPage = () => {
         <section className="text-center">
           <div className="bg-gradient-to-r from-blue-600 to-blue-800 rounded-2xl p-12 text-white">
             <h2 className="text-3xl md:text-4xl font-bold mb-6">
-              Ready to Join Our Marina Community?
+              Ready to Join Our Club Community?
             </h2>
             <div className="w-20 h-1 bg-white mx-auto mb-8"></div>
             <p className="text-xl mb-8 opacity-90 max-w-2xl mx-auto">
-              Experience world-class marina facilities, exceptional service, and a welcoming community 
+              Experience world-class club facilities, exceptional service, and a welcoming community 
               of fellow boating enthusiasts at Pleasant Park Yacht Club.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">

--- a/ppyc_frontend/src/pages/MembershipPage.jsx
+++ b/ppyc_frontend/src/pages/MembershipPage.jsx
@@ -61,9 +61,9 @@ const MembershipPage = () => {
               <div className="w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6">
                 <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} className="text-3xl text-blue-600" />
               </div>
-              <h3 className="text-2xl font-bold text-slate-800 mb-4">Premier Marina</h3>
+              <h3 className="text-2xl font-bold text-slate-800 mb-4">Premier Club</h3>
               <p className="text-slate-600 leading-relaxed">
-                Modern floating dock systems, seasonal slip assignments, and comprehensive marina services including maintenance, and winter storage.
+                Modern floating dock systems, seasonal slip assignments, and comprehensive club services including maintenance, and winter storage.
               </p>
             </div>
 
@@ -104,7 +104,7 @@ const MembershipPage = () => {
               <div className="space-y-6">
                 <h3 className="text-2xl font-bold text-slate-800 mb-6 flex items-center gap-3">
                   <FontAwesomeIcon icon={ICON_NAMES.SHIP} className="text-blue-600" />
-                  Marina & Boating
+                  Club & Boating
                 </h3>
                 
                 <div className="flex items-start gap-4">
@@ -112,7 +112,7 @@ const MembershipPage = () => {
                     <FontAwesomeIcon icon={ICON_NAMES.CHECK} className="text-blue-600 text-sm" />
                   </div>
                   <div>
-                    <h4 className="font-semibold text-slate-800 mb-1">Summer Marina Slip Assignments</h4>
+                    <h4 className="font-semibold text-slate-800 mb-1">Summer Club Slip Assignments</h4>
                     <p className="text-slate-600 text-sm">Priority seasonal moorage for the entire boating season</p>
                   </div>
                 </div>
@@ -132,7 +132,7 @@ const MembershipPage = () => {
                     <FontAwesomeIcon icon={ICON_NAMES.CHECK} className="text-blue-600 text-sm" />
                   </div>
                   <div>
-                    <h4 className="font-semibold text-slate-800 mb-1">Modern Marina Facilities</h4>
+                    <h4 className="font-semibold text-slate-800 mb-1">Modern Club Facilities</h4>
                     <p className="text-slate-600 text-sm">30 & 50 amp electrical, fresh water, pump-out station, winter storage</p>
                   </div>
                 </div>
@@ -335,7 +335,7 @@ const MembershipPage = () => {
             <div className="group">
               <img 
                 src="/assets/images/ppyc-images/sunset.jpg" 
-                alt="Marina sunsets" 
+                alt="Club sunsets" 
                 className="w-full h-32 object-cover rounded-lg shadow-md group-hover:shadow-xl transition-all duration-300 group-hover:scale-105"
               />
               <p className="text-sm text-center text-slate-600 mt-2">Scenic Location</p>
@@ -366,11 +366,11 @@ const MembershipPage = () => {
                 Get Application Form
               </a>
               <Link 
-                to="/marina" 
+                to="/club" 
                 className="px-8 py-4 border-2 border-blue-400 text-blue-400 font-semibold rounded-lg hover:bg-blue-400 hover:text-white transition-all duration-300 inline-flex items-center justify-center"
               >
                 <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} className="mr-2" />
-                Tour Our Marina
+                Tour Our Club
               </Link>
             </div>
           </div>

--- a/ppyc_frontend/src/pages/StaticPage.jsx
+++ b/ppyc_frontend/src/pages/StaticPage.jsx
@@ -153,7 +153,7 @@ const StaticPage = ({ slug }) => {
                 <div className="p-6 bg-blue-50 rounded-lg">
                   <h4 className="text-xl font-semibold text-slate-800 mb-3 flex items-center gap-2">
                     <i className="fas fa-anchor text-blue-600"></i>
-                    Marina Services
+                    Club Services
                   </h4>
                   <ul className="space-y-2 text-slate-700">
                     <li className="flex items-center gap-2">


### PR DESCRIPTION
This aligns public navigation, marketing copy, SEO metadata, and admin wording with yacht-club branding while preserving legacy /marina route compatibility.

Made-with: Cursor