### PR TITLE
Fix slide ordering and TV/weather refresh behavior.

### DIFF
--- a/ppyc_backend/app/controllers/api/v1/admin/slides_controller.rb
+++ b/ppyc_backend/app/controllers/api/v1/admin/slides_controller.rb
@@ -43,17 +43,43 @@ class Api::V1::Admin::SlidesController < Api::V1::Admin::BaseController
 
   # Bulk update display order
   def reorder
-    slides_data = params[:slides] || []
+    slides_data = Array(params[:slides])
+    if slides_data.empty?
+      return render_error('No slides provided', :bad_request)
+    end
 
-    slides_data.each do |slide_data|
-      slide = Slide.find(slide_data[:id])
-      slide.update(display_order: slide_data[:display_order])
+    Slide.transaction do
+      normalized_data = slides_data.map do |slide_data|
+        {
+          id: slide_data[:id].to_i,
+          display_order: slide_data[:display_order].to_i
+        }
+      end
+
+      slide_ids = normalized_data.map { |slide| slide[:id] }
+      slides_by_id = Slide.where(id: slide_ids).index_by(&:id)
+
+      missing_ids = slide_ids - slides_by_id.keys
+      raise ActiveRecord::RecordNotFound if missing_ids.any?
+
+      # Temporarily move all selected slides out of the current order range so
+      # we can safely re-assign unique display_order values in a second pass.
+      offset = (Slide.maximum(:display_order) || 0) + normalized_data.size + 10
+      normalized_data.each do |slide_data|
+        slides_by_id[slide_data[:id]].update_columns(display_order: slide_data[:display_order] + offset)
+      end
+
+      normalized_data.each do |slide_data|
+        slides_by_id[slide_data[:id]].update!(display_order: slide_data[:display_order])
+      end
     end
 
     slides = Slide.order(:display_order)
     render_success(slides.map { |slide| admin_slide_json(slide) })
   rescue ActiveRecord::RecordNotFound
     render_error('Slide not found', :not_found)
+  rescue ActiveRecord::RecordInvalid => e
+    render_error("Failed to reorder slides: #{e.record.errors.full_messages.join(', ')}")
   end
 
   private

--- a/ppyc_frontend/src/components/SlideWeatherWidget.jsx
+++ b/ppyc_frontend/src/components/SlideWeatherWidget.jsx
@@ -7,6 +7,13 @@ import api from '../services/api';
 const cacheKeySlug = (location, type) =>
   `${(location || 'default').replace(/[^a-zA-Z0-9.-]/g, '_')}_${type}`;
 
+const formatLocalDateYYYYMMDD = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
 const SlideWeatherWidget = ({ location, weatherType, className = '' }) => {
   const effectiveLocation = (location && location.trim()) || 'Winthrop, MA';
   const slug = cacheKeySlug(effectiveLocation, 'forecast');
@@ -38,21 +45,42 @@ const SlideWeatherWidget = ({ location, weatherType, className = '' }) => {
     );
   }
 
-  const getWeatherIcon = (condition) => {
-    if (!condition) return ICON_NAMES.SUN;
+  const getWeatherVisual = (condition) => {
+    if (!condition) {
+      return { icon: ICON_NAMES.SUN, colorClass: 'text-yellow-400' };
+    }
+
     const c = condition.toLowerCase();
-    if (c.includes('rain')) return ICON_NAMES.RAIN;
-    if (c.includes('cloud') || c.includes('overcast')) return ICON_NAMES.CLOUD;
-    if (c.includes('snow')) return ICON_NAMES.SNOW;
-    if (c.includes('thunder')) return ICON_NAMES.THUNDER;
-    if (c.includes('wind')) return ICON_NAMES.WIND;
-    if (c.includes('fog')) return ICON_NAMES.FOG;
-    return ICON_NAMES.SUN;
+
+    if (c.includes('thunder') || c.includes('storm') || c.includes('lightning')) {
+      return { icon: ICON_NAMES.THUNDER, colorClass: 'text-purple-300' };
+    }
+    if (c.includes('snow') || c.includes('ice') || c.includes('sleet') || c.includes('blizzard') || c.includes('freezing')) {
+      return { icon: ICON_NAMES.SNOW, colorClass: 'text-sky-300' };
+    }
+    if (c.includes('rain') || c.includes('drizzle') || c.includes('shower')) {
+      return { icon: ICON_NAMES.RAIN, colorClass: 'text-blue-300' };
+    }
+    if (c.includes('fog') || c.includes('mist') || c.includes('haze') || c.includes('smoke')) {
+      return { icon: ICON_NAMES.FOG, colorClass: 'text-slate-300' };
+    }
+    if (c.includes('wind') || c.includes('breezy') || c.includes('gust')) {
+      return { icon: ICON_NAMES.WIND, colorClass: 'text-teal-300' };
+    }
+    if (c.includes('partly') || c.includes('mostly')) {
+      return { icon: ICON_NAMES.CLOUD_SUN, colorClass: 'text-amber-300' };
+    }
+    if (c.includes('cloud') || c.includes('overcast')) {
+      return { icon: ICON_NAMES.CLOUD, colorClass: 'text-gray-300' };
+    }
+
+    return { icon: ICON_NAMES.SUN, colorClass: 'text-yellow-400' };
   };
 
   // 3-Day Forecast
   if (data.forecasts && data.forecasts.length > 0) {
-    const todayStr = new Date().toISOString().slice(0, 10);
+    // Use local date instead of UTC so evening hours do not skip "today".
+    const todayStr = formatLocalDateYYYYMMDD(new Date());
     const filtered = data.forecasts.filter((d) => d.date >= todayStr).slice(0, 3);
     const daysToShow = filtered.length ? filtered : data.forecasts.slice(0, 3);
 
@@ -87,6 +115,7 @@ const SlideWeatherWidget = ({ location, weatherType, className = '' }) => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 w-full mt-8">
           {daysToShow.map((day, i) => {
             const isToday = dayLabel(day.date, i) === 'Today';
+            const weatherVisual = getWeatherVisual(day.condition);
             return (
               <div
                 key={day.date || i}
@@ -101,8 +130,8 @@ const SlideWeatherWidget = ({ location, weatherType, className = '' }) => {
                   <span className="text-sm text-white/60">{formatDateShort(day.date)}</span>
                 </div>
                 <FontAwesomeIcon
-                  icon={getWeatherIcon(day.condition)}
-                  className="text-yellow-400 text-5xl mb-3"
+                  icon={weatherVisual.icon}
+                  className={`${weatherVisual.colorClass} text-5xl mb-3`}
                 />
                 <div className="text-3xl font-bold text-white">
                   {day.max_temp != null ? `${Math.round(day.max_temp)}°` : '—'}

--- a/ppyc_frontend/src/components/TVDisplay.jsx
+++ b/ppyc_frontend/src/components/TVDisplay.jsx
@@ -12,7 +12,7 @@ import { useSettings } from '../hooks/useSettings';
 const TVDisplay = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
   const [currentSlideIndex, setCurrentSlideIndex] = useState(0);
-  const { data: response, isLoading: slidesLoading, error: slidesError } = useApiCache(slidesAPI.getAll, 'slides-all', { ttl: 30000 });
+  const { data: response, isLoading: slidesLoading, error: slidesError, refresh: refreshSlides } = useApiCache(slidesAPI.getAll, 'slides-all', { ttl: 30000 });
   const slides = response?.data || [];
   const { siteTitle, enableWeather, enableTime, defaultSlideDuration } = useSettings();
 
@@ -23,6 +23,25 @@ const TVDisplay = () => {
     }, 1000);
     return () => clearInterval(timer);
   }, []);
+
+  // Keep TV content in sync with admin changes without manual page refresh.
+  useEffect(() => {
+    const refreshTimer = setInterval(() => {
+      refreshSlides();
+    }, 15000);
+
+    return () => clearInterval(refreshTimer);
+  }, [refreshSlides]);
+
+  // Ensure current index stays valid if slides are removed.
+  useEffect(() => {
+    if (slides.length === 0) {
+      setCurrentSlideIndex(0);
+      return;
+    }
+
+    setCurrentSlideIndex((prevIndex) => (prevIndex >= slides.length ? 0 : prevIndex));
+  }, [slides.length]);
 
   // Rotate slides based on their duration
   useEffect(() => {

--- a/ppyc_frontend/src/components/WeatherWidget.jsx
+++ b/ppyc_frontend/src/components/WeatherWidget.jsx
@@ -39,20 +39,42 @@ const WeatherWidget = ({ className = '', showMarine = false }) => {
     );
   }
 
-  const getWeatherIcon = (condition) => {
-    if (!condition) return ICON_NAMES.SUN;
+  const getWeatherVisual = (condition) => {
+    if (!condition) {
+      return { icon: ICON_NAMES.SUN, colorClass: 'text-yellow-400' };
+    }
+
     const conditionLower = condition.toLowerCase();
-    if (conditionLower.includes('rain')) return ICON_NAMES.RAIN;
-    if (conditionLower.includes('cloud') || conditionLower.includes('overcast')) return ICON_NAMES.CLOUD;
-    if (conditionLower.includes('snow')) return ICON_NAMES.SNOW;
-    if (conditionLower.includes('thunder')) return ICON_NAMES.THUNDER;
-    if (conditionLower.includes('wind')) return ICON_NAMES.WIND;
-    if (conditionLower.includes('fog')) return ICON_NAMES.FOG;
-    return ICON_NAMES.SUN;
+
+    if (conditionLower.includes('thunder') || conditionLower.includes('storm') || conditionLower.includes('lightning')) {
+      return { icon: ICON_NAMES.THUNDER, colorClass: 'text-purple-300' };
+    }
+    if (conditionLower.includes('snow') || conditionLower.includes('ice') || conditionLower.includes('sleet') || conditionLower.includes('blizzard') || conditionLower.includes('freezing')) {
+      return { icon: ICON_NAMES.SNOW, colorClass: 'text-sky-300' };
+    }
+    if (conditionLower.includes('rain') || conditionLower.includes('drizzle') || conditionLower.includes('shower')) {
+      return { icon: ICON_NAMES.RAIN, colorClass: 'text-blue-300' };
+    }
+    if (conditionLower.includes('fog') || conditionLower.includes('mist') || conditionLower.includes('haze') || conditionLower.includes('smoke')) {
+      return { icon: ICON_NAMES.FOG, colorClass: 'text-slate-300' };
+    }
+    if (conditionLower.includes('wind') || conditionLower.includes('breezy') || conditionLower.includes('gust')) {
+      return { icon: ICON_NAMES.WIND, colorClass: 'text-teal-300' };
+    }
+    if (conditionLower.includes('partly') || conditionLower.includes('mostly')) {
+      return { icon: ICON_NAMES.CLOUD_SUN, colorClass: 'text-amber-300' };
+    }
+    if (conditionLower.includes('cloud') || conditionLower.includes('overcast')) {
+      return { icon: ICON_NAMES.CLOUD, colorClass: 'text-gray-300' };
+    }
+
+    return { icon: ICON_NAMES.SUN, colorClass: 'text-yellow-400' };
   };
 
   // Get today's marine forecast
   const todayMarine = marine?.forecasts?.[0] || {};
+
+  const weatherVisual = getWeatherVisual(weather.condition);
 
   return (
     <div className={`flex flex-col space-y-4 ${className}`}>
@@ -61,8 +83,8 @@ const WeatherWidget = ({ className = '', showMarine = false }) => {
         {/* Temperature */}
         <div className="flex items-center text-white">
           <FontAwesomeIcon
-            icon={getWeatherIcon(weather.condition)}
-            className="mr-3 text-yellow-400 text-4xl"
+            icon={weatherVisual.icon}
+            className={`mr-3 text-4xl ${weatherVisual.colorClass}`}
           />
           <span className="text-4xl">{weather.temperature ? `${Math.round(weather.temperature)}°F` : 'N/A'}</span>
         </div>

--- a/ppyc_frontend/src/components/admin/SlideBuilder.jsx
+++ b/ppyc_frontend/src/components/admin/SlideBuilder.jsx
@@ -174,33 +174,35 @@ const SlideBuilder = () => {
   const handleDragEnd = async (event) => {
     const { active, over } = event;
 
-    if (active.id !== over.id) {
-      const oldIndex = slides.findIndex(slide => slide.id === active.id);
-      const newIndex = slides.findIndex(slide => slide.id === over.id);
+    if (!over || active.id === over.id) {
+      return;
+    }
+
+    const oldIndex = slides.findIndex(slide => slide.id === active.id);
+    const newIndex = slides.findIndex(slide => slide.id === over.id);
+    
+    const newSlides = arrayMove(slides, oldIndex, newIndex);
+    
+    // Update display_order for all slides
+    const updatedSlides = newSlides.map((slide, index) => ({
+      ...slide,
+      display_order: index + 1
+    }));
+    
+    setSlides(updatedSlides);
+    
+    try {
+      // Update order on server
+      await adminAPI.slides.reorder(updatedSlides.map(slide => ({
+        id: slide.id,
+        display_order: slide.display_order
+      })));
       
-      const newSlides = arrayMove(slides, oldIndex, newIndex);
-      
-      // Update display_order for all slides
-      const updatedSlides = newSlides.map((slide, index) => ({
-        ...slide,
-        display_order: index + 1
-      }));
-      
-      setSlides(updatedSlides);
-      
-      try {
-        // Update order on server
-        await adminAPI.slides.updateOrder(updatedSlides.map(slide => ({
-          id: slide.id,
-          display_order: slide.display_order
-        })));
-        
-        setSuccess('Slide order updated successfully!');
-        setTimeout(() => setSuccess(''), 3000);
-      } catch (err) {
-        setError(`Failed to update slide order: ${err.message || err}`);
-        fetchSlides(); // Revert on error
-      }
+      setSuccess('Slide order updated successfully!');
+      setTimeout(() => setSuccess(''), 3000);
+    } catch (err) {
+      setError(`Failed to update slide order: ${err.message || err}`);
+      fetchSlides(); // Revert on error
     }
   };
 

--- a/ppyc_frontend/src/services/api.js
+++ b/ppyc_frontend/src/services/api.js
@@ -25,7 +25,12 @@ const authApi = axios.create({
 authApi.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.status === 401) {
+    const status = error.response?.status;
+    const requestUrl = error.config?.url || '';
+    const isAuthEndpoint = requestUrl.includes('/auth/login') || requestUrl.includes('/auth/me') || requestUrl.includes('/auth/logout');
+    const isOnLoginPage = window.location.pathname.startsWith('/admin/login');
+
+    if (status === 401 && !isAuthEndpoint && !isOnLoginPage) {
       // Clear any stored user data and redirect to login
       localStorage.removeItem('currentUser');
       window.location.href = '/admin/login';


### PR DESCRIPTION
Make slide reorder updates atomic to avoid display_order conflicts, harden auth redirect handling, and keep TV/weather displays synchronized with admin changes and local-time forecast rendering.

Made-with: Cursor