### PR TITLE
Add TideCheck-powered tides slides with resilient marine caching.

### DIFF
--- a/WEATHER_API_SETUP.md
+++ b/WEATHER_API_SETUP.md
@@ -1,6 +1,10 @@
 # Weather API Setup Guide
 
-The PPYC website includes weather and marine data integration using WeatherAPI.com. The API key is securely stored on the backend to prevent exposure in the frontend code.
+The PPYC website uses:
+- **WeatherAPI.com** for current weather + forecast
+- **TideCheck** for marine tide data (with strict daily quota caching)
+
+All keys are stored on the backend to prevent exposure in frontend code.
 
 ## Security Implementation
 
@@ -23,10 +27,16 @@ cd ppyc_backend
 cp .env.example .env
 ```
 
-Edit `.env` and add your WeatherAPI key:
+Edit `.env` and add keys:
 ```bash
 WEATHER_API_KEY=your_actual_api_key_here
+TIDECHECK_API_KEY=tc_your_key_here
+TIDECHECK_STATION_ID=8443970
+# Optional (defaults to MLLW)
+TIDECHECK_DATUM=MLLW
 ```
+
+> `TIDECHECK_STATION_ID` should be a TideCheck-supported station id for your location.
 
 ### 3. Restart Rails Server
 
@@ -41,7 +51,16 @@ The backend provides these secure weather endpoints:
 
 - `GET /api/v1/weather/current?location=Boston,MA` - Current weather conditions
 - `GET /api/v1/weather/forecast?location=Boston,MA&days=3` - Weather forecast 
-- `GET /api/v1/weather/marine?location=Boston,MA&days=3` - Marine conditions
+- `GET /api/v1/weather/marine?location=Boston,MA&days=3` - Marine conditions/tides (TideCheck first, WeatherAPI fallback)
+
+## TideCheck Rate-Limit Protection
+
+TideCheck free plan allows only **50 requests/day**. The backend now protects usage by:
+- Caching TideCheck responses server-side for 6 hours per station+datum+days
+- Reusing cached responses across requests
+- Falling back to WeatherAPI marine response if TideCheck is unavailable
+
+Frontend marine calls are also cached for 6 hours to reduce repeated requests.
 
 ## Frontend Usage
 

--- a/ppyc_backend/app/controllers/api/v1/weather_controller.rb
+++ b/ppyc_backend/app/controllers/api/v1/weather_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::WeatherController < Api::V1::BaseController
   require 'net/http'
   require 'uri'
   require 'json'
+  require 'time'
 
   # GET /api/v1/weather/current?location=Winthrop,MA
   def current
@@ -67,68 +68,29 @@ class Api::V1::WeatherController < Api::V1::BaseController
     days = (params[:days] || 3).to_i
 
     begin
-      data = fetch_weather_data('marine', location, days: days)
+      tidecheck_data = fetch_tidecheck_data(location, days)
+      response = format_tidecheck_marine_response(tidecheck_data, location, days)
 
-      # Debug: log marine response structure in development (wave/swell/tides depend on plan & location)
-      if Rails.env.development? && data['forecast'] && data['forecast']['forecastday']&.first
-        fd = data['forecast']['forecastday'].first
-        Rails.logger.info "[Marine API] location=#{location} days=#{days} forecastday_keys=#{fd.keys.inspect} hour_count=#{fd['hour']&.size} first_hour_keys=#{fd['hour']&.first&.keys&.inspect} tides_count=#{fd['tides']&.size}"
+      # TideCheck excels at tides/astronomical data; blend in WeatherAPI marine
+      # wave/swell/wind fields so the UI can show a complete marine card.
+      begin
+        weather_data = fetch_weatherapi_marine_cached(location, days)
+        weather_response = format_weatherapi_marine_response(weather_data, location, days)
+        response = merge_weatherapi_fields(response, weather_response)
+      rescue => blend_error
+        Rails.logger.warn "WeatherAPI blend for marine data failed: #{blend_error.class} #{blend_error.message}"
       end
-
-      # Format the marine response (day-level + first-hour wave/swell when available + tides)
-      response = {
-        location: data['location']['name'],
-        forecasts: data['forecast']['forecastday'].map do |day|
-          raw_tides = day['tides']
-          tide_list = raw_tides.is_a?(Array) ? raw_tides : (raw_tides.is_a?(Hash) ? raw_tides.values : [])
-          tides = tide_list.map do |t|
-            {
-              time: t['tide_time'],
-              height_mt: t['tide_height_mt'],
-              type: t['tide_type']
-            }
-          end
-          # Wave/swell: day level first, then from first available hour (marine API puts wave/swell in hour element)
-          # Tides and marine hour data depend on WeatherAPI subscription and coastal location (lat/lon often works better).
-          raw_hours = day['hour']
-          hours = case raw_hours
-                  when Array then raw_hours
-                  when Hash then raw_hours.values
-                  else []
-                  end
-          day_obj = day['day'] || {}
-          first_hour = hours.first
-          first_hour_with_wave = hours.find { |h| h.key?('sig_ht_mt') && !h['sig_ht_mt'].nil? }
-          first_hour_with_swell = hours.find { |h| (h['swell_ht_ft'].present? || (h.key?('swell_ht_mt') && !h['swell_ht_mt'].nil?)) }
-          first_hour_with_wave ||= first_hour
-          first_hour_with_swell ||= first_hour
-          wave_height = day_obj['wave_height_ft'].presence
-          wave_height ||= (first_hour_with_wave && first_hour_with_wave['sig_ht_mt'] && (first_hour_with_wave['sig_ht_mt'].to_f * 3.28084).round(1))
-          wave_direction = day_obj['wave_dir_16_point'].presence || first_hour_with_wave&.dig('swell_dir_16_point')
-          swell_height = day_obj['swell_height_ft'].presence || first_hour_with_swell&.dig('swell_ht_ft')
-          swell_height ||= (first_hour_with_swell && first_hour_with_swell['swell_ht_mt'] && (first_hour_with_swell['swell_ht_mt'].to_f * 3.28084).round(1))
-          swell_direction = day_obj['swell_dir_16_point'].presence || first_hour_with_swell&.dig('swell_dir_16_point')
-          {
-            date: day['date'],
-            wave_height: wave_height,
-            wave_direction: wave_direction,
-            swell_height: swell_height,
-            swell_direction: swell_direction,
-            wind_speed: day_obj['maxwind_mph'],
-            wind_direction: day_obj['wind_dir'],
-            temperature: day_obj['maxtemp_f'],
-            condition: day_obj.dig('condition', 'text'),
-            icon_url: day_obj.dig('condition', 'icon'),
-            visibility_miles: day_obj['avgvis_miles'],
-            tides: tides
-          }
-        end
-      }
 
       render_success(response)
     rescue => e
-      Rails.logger.error "Weather API Error: #{e.message}"
-      render_error('Marine forecast unavailable', :service_unavailable)
+      Rails.logger.warn "TideCheck marine fetch failed, falling back to WeatherAPI: #{e.class} #{e.message}"
+      begin
+        weather_data = fetch_weather_data('marine', location, days: days)
+        render_success(format_weatherapi_marine_response(weather_data, location, days))
+      rescue => fallback_error
+        Rails.logger.error "Marine API fallback failed: #{fallback_error.class} #{fallback_error.message}"
+        render_error('Marine forecast unavailable', :service_unavailable)
+      end
     end
   end
 
@@ -184,6 +146,302 @@ class Api::V1::WeatherController < Api::V1::BaseController
   end
 
   private
+
+  def format_weatherapi_marine_response(data, _location, days)
+    # Debug: log marine response structure in development (wave/swell/tides depend on plan & location)
+    if Rails.env.development? && data['forecast'] && data['forecast']['forecastday']&.first
+      fd = data['forecast']['forecastday'].first
+      Rails.logger.info "[Marine API] forecastday_keys=#{fd.keys.inspect} hour_count=#{fd['hour']&.size} first_hour_keys=#{fd['hour']&.first&.keys&.inspect} tides_count=#{fd['tides']&.size}"
+    end
+
+    {
+      source: 'weatherapi',
+      location: data['location']['name'],
+      forecasts: data['forecast']['forecastday'].first(days).map do |day|
+        raw_tides = day['tides']
+        tide_list = raw_tides.is_a?(Array) ? raw_tides : (raw_tides.is_a?(Hash) ? raw_tides.values : [])
+        tides = tide_list.map do |t|
+          {
+            time: t['tide_time'],
+            height_mt: t['tide_height_mt'],
+            type: t['tide_type']
+          }
+        end
+
+        # Wave/swell: day level first, then from first available hour.
+        raw_hours = day['hour']
+        hours = case raw_hours
+                when Array then raw_hours
+                when Hash then raw_hours.values
+                else []
+                end
+        day_obj = day['day'] || {}
+        first_hour = hours.first
+        first_hour_with_wave = hours.find { |h| h.key?('sig_ht_mt') && !h['sig_ht_mt'].nil? }
+        first_hour_with_swell = hours.find { |h| (h['swell_ht_ft'].present? || (h.key?('swell_ht_mt') && !h['swell_ht_mt'].nil?)) }
+        first_hour_with_wave ||= first_hour
+        first_hour_with_swell ||= first_hour
+        wave_height = day_obj['wave_height_ft'].presence
+        wave_height ||= (first_hour_with_wave && first_hour_with_wave['sig_ht_mt'] && (first_hour_with_wave['sig_ht_mt'].to_f * 3.28084).round(1))
+        wave_direction = day_obj['wave_dir_16_point'].presence || first_hour_with_wave&.dig('swell_dir_16_point')
+        swell_height = day_obj['swell_height_ft'].presence || first_hour_with_swell&.dig('swell_ht_ft')
+        swell_height ||= (first_hour_with_swell && first_hour_with_swell['swell_ht_mt'] && (first_hour_with_swell['swell_ht_mt'].to_f * 3.28084).round(1))
+        swell_direction = day_obj['swell_dir_16_point'].presence || first_hour_with_swell&.dig('swell_dir_16_point')
+
+        {
+          date: day['date'],
+          wave_height: wave_height,
+          wave_direction: wave_direction,
+          swell_height: swell_height,
+          swell_direction: swell_direction,
+          wind_speed: day_obj['maxwind_mph'],
+          wind_direction: day_obj['wind_dir'],
+          temperature: day_obj['maxtemp_f'],
+          condition: day_obj.dig('condition', 'text'),
+          icon_url: day_obj.dig('condition', 'icon'),
+          visibility_miles: day_obj['avgvis_miles'],
+          tides: tides
+        }
+      end
+    }
+  end
+
+  def format_tidecheck_marine_response(data, location, days)
+    daily_conditions = Array(data['dailyConditions'])
+    forecasts_by_date = {}
+    all_extremes = Array(data['extremes'])
+    now = Time.current
+
+    daily_conditions.each do |day|
+      date = day['date']
+      forecasts_by_date[date] = {
+        date: date,
+        wave_height: nil,
+        wave_direction: nil,
+        swell_height: nil,
+        swell_direction: nil,
+        wind_speed: nil,
+        wind_direction: nil,
+        temperature: nil,
+        condition: nil,
+        icon_url: nil,
+        visibility_miles: nil,
+        tides: [],
+        sunrise: day['sunrise'],
+        sunset: day['sunset'],
+        moon_phase: day['moonPhase'],
+        moon_illumination: day['moonIllumination'],
+        solunar_label: day['solunarLabel'],
+        spring_neap: day['springNeap']
+      }
+    end
+
+    all_extremes.each do |extreme|
+      date = extreme['localDate'] || extreme['time']&.to_date&.iso8601
+      next if date.blank?
+
+      forecasts_by_date[date] ||= {
+        date: date,
+        wave_height: nil,
+        wave_direction: nil,
+        swell_height: nil,
+        swell_direction: nil,
+        wind_speed: nil,
+        wind_direction: nil,
+        temperature: nil,
+        condition: nil,
+        icon_url: nil,
+        visibility_miles: nil,
+        tides: []
+      }
+
+      forecasts_by_date[date][:tides] << {
+        time: extreme['time'],
+        height_mt: extreme['height'],
+        type: extreme['type']
+      }
+    end
+
+    forecasts = forecasts_by_date.values.sort_by { |forecast| forecast[:date] }.first(days)
+    forecasts.each do |forecast|
+      forecast[:tides] = forecast[:tides].sort_by { |t| t[:time].to_s }
+      heights = forecast[:tides].map { |t| t[:height_mt] }.compact
+      forecast[:tidal_range_mt] = heights.any? ? (heights.max - heights.min).round(3) : nil
+    end
+
+    future_extremes = all_extremes
+      .map do |extreme|
+        parsed = parse_iso_time(extreme['time'])
+        next nil unless parsed
+        { time: extreme['time'], parsed_time: parsed, type: extreme['type'], height_mt: extreme['height'] }
+      end
+      .compact
+      .select { |extreme| extreme[:parsed_time] >= now }
+      .sort_by { |extreme| extreme[:parsed_time] }
+
+    next_high = future_extremes.find { |extreme| extreme[:type] == 'high' }
+    next_low = future_extremes.find { |extreme| extreme[:type] == 'low' }
+
+    trend = derive_tide_trend(Array(data['timeSeries']), now)
+
+    {
+      source: 'tidecheck',
+      location: data.dig('station', 'name') || data.dig('station', 'region') || location,
+      station: {
+        id: data.dig('station', 'id'),
+        timezone: data.dig('station', 'timezone'),
+        datum: data['datum']
+      },
+      conditions: {
+        sunrise: data.dig('conditions', 'sunrise'),
+        sunset: data.dig('conditions', 'sunset'),
+        moon_phase: data.dig('conditions', 'moonPhase'),
+        moon_illumination: data.dig('conditions', 'moonIllumination'),
+        spring_neap: data.dig('conditions', 'springNeap'),
+        tidal_strength: data.dig('conditions', 'tidalStrength')
+      },
+      next_tides: {
+        high: next_high&.slice(:time, :height_mt),
+        low: next_low&.slice(:time, :height_mt)
+      },
+      trend: trend,
+      forecasts: forecasts
+    }
+  end
+
+  def derive_tide_trend(time_series, now)
+    points = time_series
+      .map do |point|
+        parsed = parse_iso_time(point['time'])
+        next nil unless parsed
+        { time: point['time'], parsed_time: parsed, height: point['height']&.to_f }
+      end
+      .compact
+      .select { |point| !point[:height].nil? }
+      .sort_by { |point| point[:parsed_time] }
+
+    return { state: nil, current_height_mt: nil } if points.size < 2
+
+    prev_point = points.reverse.find { |point| point[:parsed_time] <= now } || points[-2]
+    next_point = points.find { |point| point[:parsed_time] > prev_point[:parsed_time] } || points[-1]
+    return { state: nil, current_height_mt: prev_point[:height]&.round(3) } if prev_point == next_point
+
+    delta = next_point[:height] - prev_point[:height]
+    state = if delta > 0.01
+              'rising'
+            elsif delta < -0.01
+              'falling'
+            else
+              'slack'
+            end
+
+    {
+      state: state,
+      current_height_mt: prev_point[:height]&.round(3),
+      sampled_at: prev_point[:time]
+    }
+  end
+
+  def parse_iso_time(value)
+    return nil if value.blank?
+    Time.iso8601(value)
+  rescue ArgumentError
+    nil
+  end
+
+  def merge_weatherapi_fields(tidecheck_response, weatherapi_response)
+    merged = tidecheck_response.deep_dup
+    weather_by_date = Array(weatherapi_response[:forecasts]).index_by { |day| day[:date] || day['date'] }
+
+    merged[:forecasts] = Array(merged[:forecasts]).map do |day|
+      weather_day = weather_by_date[day[:date]]
+      next day unless weather_day
+
+      day.merge(
+        wave_height: day[:wave_height].presence || weather_day[:wave_height],
+        wave_direction: day[:wave_direction].presence || weather_day[:wave_direction],
+        swell_height: day[:swell_height].presence || weather_day[:swell_height],
+        swell_direction: day[:swell_direction].presence || weather_day[:swell_direction],
+        wind_speed: day[:wind_speed].presence || weather_day[:wind_speed],
+        wind_direction: day[:wind_direction].presence || weather_day[:wind_direction],
+        temperature: day[:temperature].presence || weather_day[:temperature],
+        condition: day[:condition].presence || weather_day[:condition],
+        icon_url: day[:icon_url].presence || weather_day[:icon_url],
+        visibility_miles: day[:visibility_miles].presence || weather_day[:visibility_miles]
+      )
+    end
+
+    merged[:source] = 'tidecheck+weatherapi'
+    merged
+  end
+
+  def fetch_tidecheck_data(location, days)
+    api_key = ENV['TIDECHECK_API_KEY']
+    station_id = ENV['TIDECHECK_STATION_ID']
+    datum = ENV.fetch('TIDECHECK_DATUM', 'MLLW')
+
+    raise 'TideCheck API key not configured' if api_key.blank?
+    raise 'TideCheck station ID not configured' if station_id.blank?
+
+    normalized_days = [[days.to_i, 1].max, 7].min
+    cache_key = "tidecheck:tides:v1:station:#{station_id}:days:#{normalized_days}:datum:#{datum}"
+
+    marine_cache_fetch(cache_key, expires_in: 6.hours) do
+      uri = URI("https://tidecheck.com/api/station/#{station_id}/tides")
+      uri.query = URI.encode_www_form(days: normalized_days, datum: datum)
+      request = Net::HTTP::Get.new(uri)
+      request['X-API-Key'] = api_key
+
+      response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        http.request(request)
+      end
+
+      unless response.code == '200'
+        raise "TideCheck returned #{response.code}: #{response.body}"
+      end
+
+      payload = JSON.parse(response.body)
+      Rails.logger.info "[TideCheck] cached tides for station=#{station_id} location=#{location} days=#{normalized_days}"
+      payload
+    end
+  end
+
+  def fetch_weatherapi_marine_cached(location, days)
+    normalized_days = [[days.to_i, 1].max, 7].min
+    normalized_location = location.to_s.strip.downcase
+    cache_key = "weatherapi:marine:v1:location:#{normalized_location}:days:#{normalized_days}"
+
+    marine_cache_fetch(cache_key, expires_in: 1.hour) do
+      fetch_weather_data('marine', location, days: normalized_days)
+    end
+  end
+
+  def marine_cache_fetch(key, expires_in:)
+    # Development may run with NullStore; keep an in-process cache to avoid
+    # exhausting low-rate external API quotas while iterating.
+    if Rails.cache.is_a?(ActiveSupport::Cache::NullStore)
+      self.class.marine_memory_cache ||= {}
+      entry = self.class.marine_memory_cache[key]
+      if entry && entry[:expires_at] > Time.current
+        return entry[:value]
+      end
+
+      value = yield
+      self.class.marine_memory_cache[key] = {
+        value: value,
+        expires_at: Time.current + expires_in
+      }
+      return value
+    end
+
+    Rails.cache.fetch(key, expires_in: expires_in, race_condition_ttl: 30.seconds) do
+      yield
+    end
+  end
+
+  class << self
+    attr_accessor :marine_memory_cache
+  end
 
   def fetch_weather_data(endpoint, location, options = {})
     api_key = ENV['WEATHER_API_KEY']

--- a/ppyc_backend/app/models/slide.rb
+++ b/ppyc_backend/app/models/slide.rb
@@ -5,7 +5,7 @@ class Slide < ApplicationRecord
 
   # Validations
   validates :title, presence: true
-  validates :slide_type, presence: true, inclusion: { in: %w[announcement event_promo photo weather] }
+  validates :slide_type, presence: true, inclusion: { in: %w[announcement event_promo photo weather tides marine_weather] }
   validates :display_order, presence: true, uniqueness: true
   validates :duration_seconds, presence: true, numericality: { greater_than: 0 }
   validates :background_tint_opacity, numericality: { greater_than_or_equal_to: 0.0, less_than_or_equal_to: 1.0 }, allow_nil: true

--- a/ppyc_frontend/src/components/SlideMarineWidget.jsx
+++ b/ppyc_frontend/src/components/SlideMarineWidget.jsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { ICON_NAMES } from '../config/fontawesome';
+import { useApiCache } from '../hooks/useApiCache';
+import api from '../services/api';
+
+const cacheKeySlug = (location) =>
+  `${(location || 'default').replace(/[^a-zA-Z0-9.-]/g, '_')}`;
+
+const formatLocalDateYYYYMMDD = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const formatDayLabel = (dateStr, index) => {
+  if (!dateStr) return `Day ${index + 1}`;
+  const day = new Date(`${dateStr}T12:00:00`);
+  return day.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+};
+
+const formatTideTime = (value) => {
+  if (!value) return 'Unknown';
+
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+  }
+
+  return value;
+};
+
+const formatRelativeTime = (value) => {
+  if (!value) return 'N/A';
+  const target = new Date(value);
+  if (Number.isNaN(target.getTime())) return 'N/A';
+
+  const diffMs = target.getTime() - Date.now();
+  const absMinutes = Math.round(Math.abs(diffMs) / 60000);
+  const hours = Math.floor(absMinutes / 60);
+  const minutes = absMinutes % 60;
+  const parts = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  parts.push(`${minutes}m`);
+  return diffMs >= 0 ? `in ${parts.join(' ')}` : `${parts.join(' ')} ago`;
+};
+
+const SlideMarineWidget = ({ location, className = '' }) => {
+  const effectiveLocation = (location && location.trim()) || 'Winthrop, MA';
+  const slug = cacheKeySlug(effectiveLocation);
+
+  const marineCall = () =>
+    api.get('/weather/marine', { params: { location: effectiveLocation, days: 5 } });
+
+  const { data: response, isLoading, error } = useApiCache(marineCall, `marine-slide-${slug}`, {
+    ttl: 6 * 60 * 60 * 1000
+  });
+
+  const data = response?.data;
+  const forecasts = data?.forecasts || [];
+  const todayStr = formatLocalDateYYYYMMDD(new Date());
+  const upcomingForecasts = forecasts.filter((day) => day.date >= todayStr).slice(0, 3);
+  const fallbackForecasts = forecasts
+    .filter((day) => !upcomingForecasts.some((upcoming) => upcoming.date === day.date))
+    .slice(0, Math.max(0, 3 - upcomingForecasts.length));
+  const daysToShow = [...upcomingForecasts, ...fallbackForecasts].slice(0, 3);
+
+  if (isLoading) {
+    return (
+      <div className={`flex items-center justify-center text-white ${className}`}>
+        <FontAwesomeIcon icon={ICON_NAMES.LOADING} spin className="mr-4 text-4xl" />
+        <span className="text-3xl">Loading marine forecast...</span>
+      </div>
+    );
+  }
+
+  if (error || !data || daysToShow.length === 0) {
+    return (
+      <div className={`flex items-center justify-center text-red-300 ${className}`}>
+        <FontAwesomeIcon icon={ICON_NAMES.WARNING} className="mr-4 text-4xl" />
+        <span className="text-3xl">Marine forecast unavailable</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`w-full max-w-6xl ${className}`}>
+      <div className="text-center mb-4">
+        <p className="text-2xl md:text-3xl text-white/90 tracking-wide">
+          {data.location || effectiveLocation}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="rounded-xl p-4 bg-white/10 border border-white/20">
+          <div className="text-white/70 text-sm">Next High Tide</div>
+          <div className="text-white text-lg font-semibold mt-1">
+            {data.next_tides?.high?.time ? formatTideTime(data.next_tides.high.time) : 'N/A'}
+          </div>
+          <div className="text-cyan-200 text-sm">
+            {data.next_tides?.high?.height_mt != null ? `${data.next_tides.high.height_mt}m` : '—'} • {formatRelativeTime(data.next_tides?.high?.time)}
+          </div>
+        </div>
+        <div className="rounded-xl p-4 bg-white/10 border border-white/20">
+          <div className="text-white/70 text-sm">Next Low Tide</div>
+          <div className="text-white text-lg font-semibold mt-1">
+            {data.next_tides?.low?.time ? formatTideTime(data.next_tides.low.time) : 'N/A'}
+          </div>
+          <div className="text-blue-200 text-sm">
+            {data.next_tides?.low?.height_mt != null ? `${data.next_tides.low.height_mt}m` : '—'} • {formatRelativeTime(data.next_tides?.low?.time)}
+          </div>
+        </div>
+        <div className="rounded-xl p-4 bg-white/10 border border-white/20">
+          <div className="text-white/70 text-sm">Current Tide Trend</div>
+          <div className="text-white text-lg font-semibold mt-1 capitalize">
+            {data.trend?.state || 'N/A'}
+          </div>
+          <div className="text-teal-200 text-sm">
+            {data.trend?.current_height_mt != null ? `${data.trend.current_height_mt}m` : '—'} {data.conditions?.tidal_strength ? `• ${data.conditions.tidal_strength}` : ''}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-6">
+        {daysToShow.map((day, index) => (
+          <div
+            key={day.date || index}
+            className="rounded-2xl p-6 bg-white/10 border-2 border-white/20 backdrop-blur-md"
+          >
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-xl font-bold text-white">{formatDayLabel(day.date, index)}</span>
+              <FontAwesomeIcon icon={ICON_NAMES.WATER} className="text-cyan-200 text-2xl" />
+            </div>
+
+            <div className="mt-4 pt-3 border-t border-white/20">
+              <div className="text-white/70 text-sm mb-1">Tide Events</div>
+              <div className="text-xs text-white/60 mb-2 uppercase tracking-wider">
+                Range: {day.tidal_range_mt != null ? `${day.tidal_range_mt}m` : 'N/A'}
+              </div>
+              {day.tides?.length ? (
+                <div className="space-y-1 text-sm text-white/90">
+                  {day.tides.slice(0, 4).map((tide, tideIndex) => (
+                    <div key={`${tide.time}-${tideIndex}`} className="flex justify-between">
+                      <span className="capitalize">{tide.type || 'tide'}</span>
+                      <span>{formatTideTime(tide.time)} ({tide.height_mt != null ? `${tide.height_mt}m` : '—'})</span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="text-sm text-white/60">No tide data available</div>
+              )}
+            </div>
+
+            {(day.solunar_label || day.moon_phase || day.spring_neap) && (
+              <div className="text-sm text-white/70 mt-3">
+                {[day.solunar_label, day.moon_phase, day.spring_neap].filter(Boolean).join(' • ')}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SlideMarineWidget;

--- a/ppyc_frontend/src/components/TVDisplay.jsx
+++ b/ppyc_frontend/src/components/TVDisplay.jsx
@@ -5,6 +5,7 @@ import { YACHT_CLUB_ASSETS } from '../config/cloudinary';
 import CloudinaryVideo from './CloudinaryVideo';
 import WeatherWidget from './WeatherWidget';
 import SlideWeatherWidget from './SlideWeatherWidget';
+import SlideMarineWidget from './SlideMarineWidget';
 import { useApiCache } from '../hooks/useApiCache';
 import { slidesAPI } from '../services/api';
 import { useSettings } from '../hooks/useSettings';
@@ -207,8 +208,8 @@ const TVDisplay = () => {
             {enableWeather && <WeatherWidget className="text-3xl" showMarine={true} />}
             </div>
 
-            {/* Slide Content - flex-1 min-h-0 so it shrinks and doesn't push footer off */}
-            <div className="flex-1 flex items-center justify-center p-4 md:p-6 min-h-0 overflow-auto">
+            {/* Slide Content: start higher and reserve footer space in normal flow */}
+            <div className="flex-1 flex items-start justify-center px-4 md:px-6 pt-2 md:pt-4 pb-4 min-h-0 overflow-auto">
               <div className="text-center max-w-6xl w-full mx-auto">
                 {slides[currentSlideIndex].slide_type === 'weather' ? (
                   <>
@@ -221,6 +222,21 @@ const TVDisplay = () => {
                       location={slides[currentSlideIndex].location}
                       weatherType={slides[currentSlideIndex].weather_type || 'current'}
                     />
+                    {slides[currentSlideIndex].content && (
+                      <div
+                        className="mt-8 text-3xl text-gray-100 leading-relaxed prose prose-invert max-w-none"
+                        dangerouslySetInnerHTML={{ __html: slides[currentSlideIndex].content }}
+                      />
+                    )}
+                  </>
+                ) : (slides[currentSlideIndex].slide_type === 'marine_weather' || slides[currentSlideIndex].slide_type === 'tides') ? (
+                  <>
+                    {slides[currentSlideIndex].title && (
+                      <h1 className="text-4xl md:text-5xl font-bold text-white mb-3 md:mb-4 tracking-tight">
+                        {slides[currentSlideIndex].title}
+                      </h1>
+                    )}
+                    <SlideMarineWidget location={slides[currentSlideIndex].location} />
                     {slides[currentSlideIndex].content && (
                       <div
                         className="mt-8 text-3xl text-gray-100 leading-relaxed prose prose-invert max-w-none"
@@ -248,7 +264,7 @@ const TVDisplay = () => {
             </div>
 
             {/* Footer */}
-            <div className="absolute bottom-0 left-0 right-0 p-4 md:p-6 flex-shrink-0">
+            <div className="p-4 md:p-6 flex-shrink-0">
               <div className="flex justify-between items-center">
                 <div className="text-xl md:text-2xl text-white">
                   <FontAwesomeIcon icon={ICON_NAMES.SHIP} className="mr-4" />

--- a/ppyc_frontend/src/components/WeatherWidget.jsx
+++ b/ppyc_frontend/src/components/WeatherWidget.jsx
@@ -6,7 +6,7 @@ import { weatherAPI } from '../services/api';
 
 const WeatherWidget = ({ className = '', showMarine = false }) => {
   const { data: weatherResponse, isLoading: weatherLoading, error: weatherError } = useApiCache(weatherAPI.getCurrent, 'weather-current', { ttl: 300000 });
-  const { data: marineResponse, isLoading: marineLoading, error: marineError } = useApiCache(weatherAPI.getMarine, 'weather-marine', { ttl: 600000 });
+  const { data: marineResponse, isLoading: marineLoading, error: marineError } = useApiCache(weatherAPI.getMarine, 'weather-marine', { ttl: 6 * 60 * 60 * 1000 });
 
   // The weather data is in the response.data
   const weather = weatherResponse?.data;

--- a/ppyc_frontend/src/components/admin/SlideBuilder.jsx
+++ b/ppyc_frontend/src/components/admin/SlideBuilder.jsx
@@ -151,6 +151,12 @@ const SlideBuilder = () => {
       name: 'Weather Info',
       icon: 'fas fa-cloud-sun',
       description: 'Display weather information'
+    },
+    {
+      type: 'tides',
+      name: 'Tides',
+      icon: 'fas fa-water',
+      description: 'Display tide times and trends'
     }
   ];
 
@@ -210,7 +216,7 @@ const SlideBuilder = () => {
     setEditingSlide(slide);
     setFormData({
       title: slide.title || '',
-      slide_type: slide.slide_type || 'announcement',
+      slide_type: slide.slide_type === 'marine_weather' ? 'tides' : (slide.slide_type || 'announcement'),
       content: slide.content || '',
       duration_seconds: slide.duration_seconds || 8,
       active_status: slide.active_status,
@@ -412,7 +418,7 @@ const SlideBuilder = () => {
                   <label className="block text-sm font-medium text-gray-700 mb-3">
                     Slide Template
                   </label>
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+                  <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
                     {slideTemplates.map((template) => (
                       <button
                         key={template.type}

--- a/ppyc_frontend/src/components/admin/SlideForm.jsx
+++ b/ppyc_frontend/src/components/admin/SlideForm.jsx
@@ -33,7 +33,8 @@ const SlideForm = () => {
     { value: 'announcement', label: 'Announcement', icon: ICON_NAMES.ANNOUNCEMENT, color: 'text-blue-600', description: 'General announcements and news' },
     { value: 'event_promo', label: 'Event Promotion', icon: ICON_NAMES.CALENDAR_ALT, color: 'text-green-600', description: 'Promote upcoming events' },
     { value: 'photo', label: 'Photo Slide', icon: ICON_NAMES.IMAGE, color: 'text-purple-600', description: 'Display photos with optional text' },
-    { value: 'weather', label: 'Weather Display', icon: ICON_NAMES.CLOUD_SUN, color: 'text-orange-600', description: 'Show 3-day weather forecast' }
+    { value: 'weather', label: 'Weather Display', icon: ICON_NAMES.CLOUD_SUN, color: 'text-orange-600', description: 'Show 3-day weather forecast' },
+    { value: 'tides', label: 'Tides', icon: ICON_NAMES.WATER, color: 'text-cyan-600', description: 'Show tide times and trends' }
   ];
 
   useEffect(() => {
@@ -49,7 +50,7 @@ const SlideForm = () => {
         const slide = response.data;
         setFormData({
           title: slide.title || '',
-          slide_type: slide.slide_type || 'announcement',
+          slide_type: slide.slide_type === 'marine_weather' ? 'tides' : (slide.slide_type || 'announcement'),
           content: slide.content || '',
           duration_seconds: slide.duration_seconds || 60,
           active_status: slide.active_status !== undefined ? slide.active_status : true,
@@ -166,9 +167,9 @@ const SlideForm = () => {
       }
 
       // Add weather-specific fields
-      if (formData.slide_type === 'weather') {
+      if (formData.slide_type === 'weather' || formData.slide_type === 'tides') {
         formDataToSend.append('slide[location]', formData.location || '');
-        formDataToSend.append('slide[weather_type]', 'forecast');
+        formDataToSend.append('slide[weather_type]', formData.slide_type === 'tides' ? 'marine' : 'forecast');
       }
 
       // Save the slide
@@ -431,7 +432,7 @@ const SlideForm = () => {
             <FontAwesomeIcon icon={ICON_NAMES.LAYER_GROUP} className="mr-2 text-gray-400" />
             Slide Type *
           </label>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
             {slideTypes.map((type) => (
               <div key={type.value}>
                 <input
@@ -463,7 +464,7 @@ const SlideForm = () => {
         </div>
 
         {/* Weather-specific fields */}
-        {formData.slide_type === 'weather' && (
+        {(formData.slide_type === 'weather' || formData.slide_type === 'tides') && (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
               <label htmlFor="weather_location" className="block text-sm font-medium text-gray-700 mb-2">
@@ -476,7 +477,7 @@ const SlideForm = () => {
                 name="location"
                 value={formData.location}
                 onChange={handleInputChange}
-                required={formData.slide_type === 'weather'}
+                required={formData.slide_type === 'weather' || formData.slide_type === 'tides'}
                 className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent text-gray-900"
                 placeholder="e.g., Boston, MA or 42.3601,-71.0589"
               />
@@ -486,8 +487,10 @@ const SlideForm = () => {
             </div>
 
             <p className="text-sm text-gray-600">
-              <FontAwesomeIcon icon={ICON_NAMES.CLOUD_SUN} className="mr-2 text-gray-400" />
-              3-day forecast for the location below
+              <FontAwesomeIcon icon={formData.slide_type === 'tides' ? ICON_NAMES.WATER : ICON_NAMES.CLOUD_SUN} className="mr-2 text-gray-400" />
+              {formData.slide_type === 'tides'
+                ? 'Tide-focused display for the location below'
+                : '3-day weather forecast for the location below'}
             </p>
           </div>
         )}
@@ -546,6 +549,8 @@ const SlideForm = () => {
                 ? 'Enter your announcement text...'
                 : formData.slide_type === 'event_promo'
                 ? 'Enter event details...'
+                : formData.slide_type === 'tides'
+                ? 'Optional notes for the tide display...'
                 : 'Optional caption for the photo...'
             }
             height={200}
@@ -554,6 +559,8 @@ const SlideForm = () => {
             {formData.slide_type === 'announcement' && 'Main text content for the announcement'}
             {formData.slide_type === 'event_promo' && 'Event description and details'}
             {formData.slide_type === 'photo' && 'Optional caption or description for the photo'}
+            {formData.slide_type === 'weather' && 'Optional notes shown below the weather forecast'}
+            {formData.slide_type === 'tides' && 'Optional notes shown below the tide display'}
           </p>
         </div>
 

--- a/ppyc_frontend/src/components/admin/SlidesList.jsx
+++ b/ppyc_frontend/src/components/admin/SlidesList.jsx
@@ -106,6 +106,11 @@ const SlidesList = () => {
         return 'calendar-alt';
       case 'photo':
         return 'image';
+      case 'weather':
+        return 'cloud-sun';
+      case 'tides':
+      case 'marine_weather':
+        return 'water';
       default:
         return 'desktop';
     }
@@ -119,6 +124,11 @@ const SlidesList = () => {
         return 'bg-green-100 text-green-800';
       case 'photo':
         return 'bg-purple-100 text-purple-800';
+      case 'weather':
+        return 'bg-orange-100 text-orange-800';
+      case 'tides':
+      case 'marine_weather':
+        return 'bg-cyan-100 text-cyan-800';
       default:
         return 'bg-gray-100 text-gray-800';
     }

--- a/ppyc_frontend/src/services/api.js
+++ b/ppyc_frontend/src/services/api.js
@@ -104,7 +104,7 @@ export const weatherAPI = {
   getMarine: createCachedCall(
     () => api.get('/weather/marine?days=3'),
     'weather-marine',
-    10 * 60 * 1000 // 10 minutes cache for marine data
+    6 * 60 * 60 * 1000 // 6 hours cache for marine data (protects low daily API quotas)
   ),
 };
 


### PR DESCRIPTION
Introduce a dedicated tides slide experience backed by TideCheck data, blend in fallback marine fields, and harden cache/TV layout behavior so long-running displays remain readable and quota-safe.

Made-with: Cursor