### PR TITLE
Fix force_ssl causing connection timeout

### DIFF
--- a/ppyc_backend/config/environments/production.rb
+++ b/ppyc_backend/config/environments/production.rb
@@ -38,11 +38,13 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy (nginx).
+  # nginx handles SSL termination and passes X-Forwarded-Proto to Rails.
   config.assume_ssl = true
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # Do NOT set force_ssl here — nginx handles HTTPS redirect and HSTS.
+  # Setting force_ssl causes redirect loops when nginx proxies HTTP to Puma.
+  config.force_ssl = false
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
## Summary

- Disable `force_ssl` in Rails — nginx handles SSL termination via certbot
- `force_ssl = true` caused `ERR_CONNECTION_TIMED_OUT` because nginx proxies to Puma over HTTP on port 3000, and Rails was redirecting internally to HTTPS

## Test plan

- [x] Site verified live at https://ppyc1910.org after fix