### PR TITLE
Fix CSP violation, link contrast, and video poster size

### DIFF
--- a/ppyc_frontend/index.prod.html
+++ b/ppyc_frontend/index.prod.html
@@ -41,12 +41,10 @@
     <!-- Preload Critical Assets -->
     <link rel="preload" href="/assets/images/ppyclogo.webp" as="image" type="image/webp" />
 
-    <!-- Fonts (non-render-blocking via media swap) -->
+    <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
-    <noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet" /></noscript>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@400;600;700&display=swap" rel="stylesheet" />
     
     <title>Pleasant Park Yacht Club</title>
   </head>

--- a/ppyc_frontend/src/components/home/HeritageSection.jsx
+++ b/ppyc_frontend/src/components/home/HeritageSection.jsx
@@ -34,7 +34,7 @@ const HeritageSection = () => {
             <h3 className="text-2xl font-bold text-slate-800 mb-4">Maritime Community</h3>
             <p className="text-gray-600 leading-relaxed">
               Building lasting friendships through shared adventures on the water. Proud member of 
-              the <a href="https://www.mbyca.org/" target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">Massachusetts Boating & Yacht Clubs Association</a>.
+              the <a href="https://www.mbyca.org/" target="_blank" rel="noopener noreferrer" className="text-blue-700 underline hover:text-blue-900">Massachusetts Boating & Yacht Clubs Association</a>.
             </p>
           </div>
           

--- a/ppyc_frontend/src/components/home/HeroSection.jsx
+++ b/ppyc_frontend/src/components/home/HeroSection.jsx
@@ -33,7 +33,7 @@ const HeroSection = () => {
           loop
           playsInline
           preload="none"
-          poster="https://res.cloudinary.com/dqb8hp68j/video/upload/q_auto,f_auto,w_1280,so_0/v1751693180/ppyc/ppyc/slides/videos/cloudinaryfile_wttzjq.jpg"
+          poster="https://res.cloudinary.com/dqb8hp68j/video/upload/q_auto:low,f_auto,w_960,so_0/v1751693180/ppyc/ppyc/slides/videos/cloudinaryfile_wttzjq.jpg"
           className="w-full h-full object-cover"
         >
           {/* Source set dynamically via useEffect */}


### PR DESCRIPTION
## Summary

- Remove inline `onload` handler that violated CSP `script-src` policy (caused Best Practices drop to 92)
- Fix MBYCA link contrast — `text-blue-700 underline` for proper distinguishability
- Reduce video poster from ~160KB to ~60KB via `q_auto:low,w_960`

## Test plan
- [x] Build passes, no inline handlers in output
- [ ] After deploy: re-run PageSpeed — Best Practices should recover to 96+

🤖 Generated with [Claude Code](https://claude.com/claude-code)