### PR TITLE
Fix desktop performance: defer FontAwesome, inline font CSS

### DIFF
--- a/ppyc_frontend/index.prod.html
+++ b/ppyc_frontend/index.prod.html
@@ -41,8 +41,13 @@
     <!-- Preload Critical Assets -->
     <link rel="preload" href="/assets/images/ppyclogo.webp" as="image" type="image/webp" />
 
-    <!-- Self-hosted Fonts (eliminates render-blocking Google Fonts request) -->
-    <link rel="stylesheet" href="/fonts/fonts.css" />
+    <!-- Inlined font declarations (eliminates extra render-blocking request) -->
+    <style>
+      @font-face{font-family:'Inter';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/inter-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}
+      @font-face{font-family:'Inter';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/inter-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}
+      @font-face{font-family:'Playfair Display';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/playfair-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}
+      @font-face{font-family:'Playfair Display';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/playfair-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}
+    </style>
     
     <title>Pleasant Park Yacht Club</title>
   </head>

--- a/ppyc_frontend/src/App.jsx
+++ b/ppyc_frontend/src/App.jsx
@@ -9,8 +9,8 @@ import { AuthProvider } from './contexts/AuthContext';
 import { ContactProvider } from './contexts/ContactProvider';
 import { SettingsProvider } from './contexts/SettingsContext';
 
-// Initialize FontAwesome icons
-import './config/fontawesome';
+// Defer FontAwesome initialization to reduce main-thread blocking
+import('./config/fontawesome');
 
 // Development-only performance monitoring
 const PerformanceMonitor = lazy(() => import('./components/PerformanceMonitor'));

--- a/ppyc_frontend/src/config/fontawesome.js
+++ b/ppyc_frontend/src/config/fontawesome.js
@@ -5,7 +5,7 @@
 import { config, library } from '@fortawesome/fontawesome-svg-core';
 
 // Configure FontAwesome to work with the kit
-config.autoAddCss = true; // Let React handle CSS for components
+config.autoAddCss = false; // CSS is bundled by Vite, no need for runtime injection
 config.searchPseudoElements = false; // Kit handles pseudo elements
 
 // Since we're using a kit, we need to tell the library about the icons

--- a/ppyc_frontend/src/input.css
+++ b/ppyc_frontend/src/input.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+@import '@fortawesome/fontawesome-svg-core/styles.css';
 
 
 /* CSS Variables for Professional Theme */


### PR DESCRIPTION
## Summary

Desktop PageSpeed was **62** due to **1,160ms Total Blocking Time** from synchronous FontAwesome initialization (75+ icon imports + library.add at startup).

- Defer FontAwesome config via `import()` instead of static `import`
- Disable `autoAddCss` — CSS now bundled by Vite via `input.css`
- Inline `@font-face` declarations into HTML head (eliminates 230ms `fonts.css` render-blocking request)

## Expected impact
- Desktop TBT: 1,160ms → ~200ms
- Desktop Performance: 62 → 85+
- Mobile should stay at 95+

## Test plan
- [x] Build passes
- [x] No external font links in built HTML
- [x] 4 @font-face rules inlined in HTML head
- [ ] After deploy: re-run PageSpeed for desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)