### PR TITLE
Fix hero video, optimize Cloudinary assets across all pages

### DIFF
--- a/ppyc_frontend/index.prod.html
+++ b/ppyc_frontend/index.prod.html
@@ -40,6 +40,7 @@
 
     <!-- Preload Critical Assets -->
     <link rel="preload" href="/assets/images/ppyclogo.webp" as="image" type="image/webp" />
+    <link rel="preconnect" href="https://res.cloudinary.com" crossorigin />
 
     <!-- Inlined font declarations (eliminates extra render-blocking request) -->
     <style>

--- a/ppyc_frontend/src/components/CloudinaryVideo.jsx
+++ b/ppyc_frontend/src/components/CloudinaryVideo.jsx
@@ -12,7 +12,7 @@ const CloudinaryVideo = ({
   playsInline = true,
   generatePoster = true,
   quality = 'auto',
-  preload = 'auto',
+  preload = 'none',
   ...props
 }) => {
   const [isLoading, setIsLoading] = useState(true);

--- a/ppyc_frontend/src/components/home/HeroSection.jsx
+++ b/ppyc_frontend/src/components/home/HeroSection.jsx
@@ -1,25 +1,21 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 
 const HeroSection = () => {
-  const [videoLoaded, setVideoLoaded] = useState(false);
   const videoRef = useRef(null);
 
   useEffect(() => {
-    // Defer video loading until after critical content renders
-    const loadVideo = () => {
+    // Short delay to let critical content paint first, then load video
+    const timer = setTimeout(() => {
       if (videoRef.current) {
-        videoRef.current.src = "https://res.cloudinary.com/dqb8hp68j/video/upload/q_auto,f_auto/v1751693180/ppyc/ppyc/slides/videos/cloudinaryfile_wttzjq.mp4";
-        videoRef.current.load();
-        setVideoLoaded(true);
+        const video = videoRef.current;
+        video.src = "https://res.cloudinary.com/dqb8hp68j/video/upload/q_auto,f_auto/v1751693180/ppyc/ppyc/slides/videos/cloudinaryfile_wttzjq.mp4";
+        video.load();
+        video.play().catch(() => {});
       }
-    };
+    }, 100);
 
-    if ('requestIdleCallback' in window) {
-      requestIdleCallback(loadVideo);
-    } else {
-      setTimeout(loadVideo, 1000);
-    }
+    return () => clearTimeout(timer);
   }, []);
 
   return (
@@ -36,7 +32,6 @@ const HeroSection = () => {
           poster="https://res.cloudinary.com/dqb8hp68j/video/upload/q_auto:low,f_auto,w_960,so_0/v1751693180/ppyc/ppyc/slides/videos/cloudinaryfile_wttzjq.jpg"
           className="w-full h-full object-cover"
         >
-          {/* Source set dynamically via useEffect */}
           Your browser does not support the video tag.
         </video>
         {/* Overlay for text readability */}

--- a/ppyc_frontend/src/config/cloudinary.js
+++ b/ppyc_frontend/src/config/cloudinary.js
@@ -36,15 +36,15 @@ export const YACHT_CLUB_ASSETS = {
   gallery: {
     // Marina and facilities - using demo cloud for sample images
     marina: [
-      `https://res.cloudinary.com/dqb8hp68j/image/upload/v1751928001/ppyc/people/members/j-farr-pic-2`,
-      `https://res.cloudinary.com/dqb8hp68j/image/upload/ppyc/ppyc/marina/cloudinaryfile_x2upsu`,
-      `https://res.cloudinary.com/dqb8hp68j/image/upload/v1751928021/ppyc/general/misc/middaysun.jpg`,
+      `https://res.cloudinary.com/dqb8hp68j/image/upload/c_fill,w_800,h_600,q_auto,f_auto/v1751928001/ppyc/people/members/j-farr-pic-2`,
+      `https://res.cloudinary.com/dqb8hp68j/image/upload/c_fill,w_800,h_600,q_auto,f_auto/ppyc/ppyc/marina/cloudinaryfile_x2upsu`,
+      `https://res.cloudinary.com/dqb8hp68j/image/upload/c_fill,w_800,h_600,q_auto,f_auto/v1751928021/ppyc/general/misc/middaysun.jpg`,
       `https://res.cloudinary.com/demo/image/upload/c_fill,w_800,h_600,q_auto,f_auto/v1/samples/landscapes/water-sunset`,
     ],
     // Events and activities - using demo cloud for sample images
     events: [
-      `https://res.cloudinary.com/dqb8hp68j/image/upload/v1751928021/ppyc/events/parties/kickoffparty1.jpg`,
-      `https://res.cloudinary.com/dqb8hp68j/image/upload/ppyc/ppyc/marina/cloudinaryfile_wcr0xt`,
+      `https://res.cloudinary.com/dqb8hp68j/image/upload/c_fill,w_800,h_600,q_auto,f_auto/v1751928021/ppyc/events/parties/kickoffparty1.jpg`,
+      `https://res.cloudinary.com/dqb8hp68j/image/upload/c_fill,w_800,h_600,q_auto,f_auto/ppyc/ppyc/marina/cloudinaryfile_wcr0xt`,
       `https://res.cloudinary.com/demo/image/upload/c_fill,w_600,h_400,q_auto,f_auto/v1/samples/landscapes/sea-beach-boardwalk`,
     ],
     // Sailing and racing - using demo cloud for sample images

--- a/ppyc_frontend/src/pages/AboutPage.jsx
+++ b/ppyc_frontend/src/pages/AboutPage.jsx
@@ -274,7 +274,7 @@ function AboutPage() {
             </p>
             <Link 
               to="/membership" 
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-600 text-white font-bold py-3 px-8 rounded-lg transition-colors"
+              className="inline-flex items-center gap-2 bg-amber-600 hover:bg-amber-700 text-white font-bold py-3 px-8 rounded-lg transition-colors"
             >
               <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} />
               Learn About Membership


### PR DESCRIPTION
## Summary

Applies performance and accessibility fixes across all pages, not just the home page.

- **Hero video not playing**: Replace `requestIdleCallback` with `setTimeout(100ms)` + `play()` for reliable autoplay
- **CloudinaryVideo default**: Change `preload` from `"auto"` to `"none"` — affects About, Events, Heritage, Marina, News, Membership pages (all use decorative background videos)
- **Cloudinary image transforms**: Add `c_fill,w_800,h_600,q_auto,f_auto` to all gallery URLs — was serving 2000x1500 originals
- **Preconnect**: Add `res.cloudinary.com` preconnect hint (every page loads Cloudinary content)
- **Contrast**: Fix amber button on About page (amber-500 → amber-600)

## Test plan
- [x] Build passes
- [ ] Hero video plays on home page
- [ ] About page images load at proper size (~800x600 instead of 2000x1500)
- [ ] After deploy: re-run PageSpeed for /about and other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)