### PR TITLE
Fix Cloudinary video 404s and button contrast

### DIFF
--- a/ppyc_frontend/src/config/cloudinary.js
+++ b/ppyc_frontend/src/config/cloudinary.js
@@ -3,7 +3,7 @@
 
 // Base Cloudinary configuration
 const cloudinaryConfig = {
-  cloudName: import.meta.env.VITE_CLOUDINARY_CLOUD_NAME || 'demo',
+  cloudName: import.meta.env.VITE_CLOUDINARY_CLOUD_NAME || 'dqb8hp68j',
   apiKey: import.meta.env.VITE_CLOUDINARY_API_KEY || '',
   apiSecret: import.meta.env.VITE_CLOUDINARY_API_SECRET || '',
 };

--- a/ppyc_frontend/src/pages/AboutPage.jsx
+++ b/ppyc_frontend/src/pages/AboutPage.jsx
@@ -274,7 +274,7 @@ function AboutPage() {
             </p>
             <Link 
               to="/membership" 
-              className="inline-flex items-center gap-2 bg-amber-600 hover:bg-amber-700 text-white font-bold py-3 px-8 rounded-lg transition-colors"
+              className="inline-flex items-center gap-2 bg-amber-700 hover:bg-amber-800 text-white font-bold py-3 px-8 rounded-lg transition-colors"
             >
               <FontAwesomeIcon icon={ICON_NAMES.ANCHOR} />
               Learn About Membership


### PR DESCRIPTION
## Summary

- **Root cause of all video 404s**: `cloudName` defaulted to `'demo'` when VPS has no `.env` file. Changed fallback to `'dqb8hp68j'` (the actual cloud). This fixes hero videos on Home, About, Events, Heritage, Marina, News, and Membership pages.
- **Contrast**: Amber CTA button darkened to `amber-700` (amber-600 still failed WCAG)

## Test plan
- [x] Build passes
- [ ] Videos play on all pages after deploy
- [ ] Button passes WCAG contrast check

🤖 Generated with [Claude Code](https://claude.com/claude-code)