### PR TITLE
Optimize dynamic Cloudinary images and video posters across all pages

### DIFF
--- a/ppyc_frontend/src/components/home/LatestNewsSection.jsx
+++ b/ppyc_frontend/src/components/home/LatestNewsSection.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ICON_NAMES } from '../../config/fontawesome';
 import { newsAPI } from '../../services/api';
 import { useApiCache } from '../../hooks/useApiCache';
+import { optimizeCloudinaryUrl } from '../../config/cloudinary';
 
 const LatestNewsSection = () => {
   const [news, setNews] = useState([]);
@@ -61,7 +62,7 @@ const LatestNewsSection = () => {
               {article.featured_image_url && (
                 <div className="relative bg-gray-100 flex items-center justify-center overflow-hidden">
                   <img
-                    src={article.featured_image_url}
+                    src={optimizeCloudinaryUrl(article.featured_image_url, { width: 640, height: 480 })}
                     alt={article.title}
                     className="w-full h-auto object-contain max-h-[300px] transition-transform duration-200 group-hover:scale-105"
                     style={{ maxWidth: '100%', display: 'block' }}

--- a/ppyc_frontend/src/components/home/UpcomingEventsSection.jsx
+++ b/ppyc_frontend/src/components/home/UpcomingEventsSection.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ICON_NAMES } from '../../config/fontawesome';
 import { eventsAPI } from '../../services/api';
 import { useApiCache } from '../../hooks/useApiCache';
+import { optimizeCloudinaryUrl } from '../../config/cloudinary';
 
 const UpcomingEventsSection = () => {
   const [events, setEvents] = useState([]);
@@ -61,7 +62,7 @@ const UpcomingEventsSection = () => {
                   onClick={() => setSelectedImage({ url: event.image_url, title: event.title })}
                 >
                   <img
-                    src={event.image_url}
+                    src={optimizeCloudinaryUrl(event.image_url, { width: 640, height: 480 })}
                     alt={event.title}
                     className="w-full h-auto object-contain max-h-[300px] transition-transform duration-200 group-hover:scale-105"
                     style={{ maxWidth: '100%', display: 'block' }}

--- a/ppyc_frontend/src/config/cloudinary.js
+++ b/ppyc_frontend/src/config/cloudinary.js
@@ -113,7 +113,7 @@ export const generateVideoUrl = (publicId, options = {}) => {
 // Generate a high-quality poster
 export const generatePosterUrl = (publicId) => {
   const posterParams = [
-    'q_auto:best',    // Best quality for the poster
+    'q_auto:low',     // Low quality is fine for a video poster placeholder
     'f_auto',         // Auto format
     'w_960',          // Match video width
     'c_scale',        // Scale transformation
@@ -157,6 +157,23 @@ export const createOptimizedImageProps = (publicId, alt, transformations = {}) =
     decoding: 'async',
     style: { aspectRatio: transformations.aspectRatio || 'auto' },
   };
+};
+
+// Add transforms to an existing Cloudinary URL (for dynamic API content)
+export const optimizeCloudinaryUrl = (url, { width = 800, height, quality = 'auto', format = 'auto', crop = 'fill' } = {}) => {
+  if (!url || !url.includes('res.cloudinary.com')) return url;
+  // Don't double-transform URLs that already have params
+  if (url.includes('/c_fill') || url.includes('/c_scale') || url.includes('/q_auto')) return url;
+
+  const transforms = [
+    `c_${crop}`,
+    `w_${width}`,
+    height && `h_${height}`,
+    `q_${quality}`,
+    `f_${format}`,
+  ].filter(Boolean).join(',');
+
+  return url.replace('/upload/', `/upload/${transforms}/`);
 };
 
 export default cloudinaryConfig; 

--- a/ppyc_frontend/src/pages/EventDetailsPage.jsx
+++ b/ppyc_frontend/src/pages/EventDetailsPage.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ICON_NAMES } from '../config/fontawesome';
 import SEOHelmet from '../components/SEOHelmet';
 import { eventsAPI } from '../services/api';
+import { optimizeCloudinaryUrl } from '../config/cloudinary';
 import { useApiCache } from '../hooks/useApiCache';
 import { sanitizeHtml } from '../utils/htmlUtils';
 
@@ -106,7 +107,7 @@ const EventDetailsPage = () => {
             {event.image_url && (
               <div className="w-full h-80 sm:h-96 overflow-hidden">
                 <img
-                  src={event.image_url}
+                  src={optimizeCloudinaryUrl(event.image_url, { width: 800, height: 600 })}
                   alt={event.title}
                   className="w-full h-full object-cover"
                   loading="lazy"

--- a/ppyc_frontend/src/pages/EventsPage.jsx
+++ b/ppyc_frontend/src/pages/EventsPage.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ICON_NAMES } from '../config/fontawesome';
 import SEOHelmet from '../components/SEOHelmet';
-import { YACHT_CLUB_ASSETS } from '../config/cloudinary';
+import { YACHT_CLUB_ASSETS, optimizeCloudinaryUrl } from '../config/cloudinary';
 import CloudinaryVideo from '../components/CloudinaryVideo';
 import { eventsAPI } from '../services/api';
 import { sanitizeHtml } from '../utils/htmlUtils';
@@ -179,7 +179,7 @@ const EventsPage = () => {
                             onClick={(e) => handleImageClick(e, event.image_url, event.title, event.description)}
                           >
                             <img
-                              src={event.image_url}
+                              src={optimizeCloudinaryUrl(event.image_url, { width: 640, height: 480 })}
                               alt={event.title}
                               className="w-full h-auto object-contain max-h-[500px] transition-transform duration-200 group-hover:scale-105"
                               style={{ maxWidth: '100%', display: 'block' }}

--- a/ppyc_frontend/src/pages/NewsPage.jsx
+++ b/ppyc_frontend/src/pages/NewsPage.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ICON_NAMES } from '../config/fontawesome';
 import SEOHelmet from '../components/SEOHelmet';
-import { YACHT_CLUB_ASSETS } from '../config/cloudinary';
+import { YACHT_CLUB_ASSETS, optimizeCloudinaryUrl } from '../config/cloudinary';
 import CloudinaryVideo from '../components/CloudinaryVideo';
 import { newsAPI } from '../services/api';
 
@@ -97,7 +97,7 @@ const NewsPage = () => {
                 {post.featured_image_url && (
                   <div className="relative bg-gray-100 flex items-center justify-center overflow-hidden">
                     <img
-                      src={post.featured_image_url}
+                      src={optimizeCloudinaryUrl(post.featured_image_url, { width: 640, height: 480 })}
                       alt={post.title}
                       className="w-full h-auto object-contain max-h-[300px] transition-transform duration-200 group-hover:scale-105"
                       style={{ maxWidth: '100%', display: 'block' }}

--- a/ppyc_frontend/src/pages/PostDetailsPage.jsx
+++ b/ppyc_frontend/src/pages/PostDetailsPage.jsx
@@ -4,6 +4,7 @@ import { newsAPI } from '../services/api';
 import { useApiCache } from '../hooks/useApiCache';
 import { logError } from '../utils/safeLogger';
 import { sanitizeHtml } from '../utils/htmlUtils';
+import { optimizeCloudinaryUrl } from '../config/cloudinary';
 
 const PostDetailsPage = () => {
   const { slug } = useParams();
@@ -106,7 +107,7 @@ const PostDetailsPage = () => {
             {post?.featured_image_url && (
               <div className="w-full h-96 overflow-hidden">
                 <img
-                  src={post.featured_image_url}
+                  src={optimizeCloudinaryUrl(post.featured_image_url, { width: 800, height: 600 })}
                   alt={post.title}
                   className="w-full h-full object-cover"
                   loading="lazy"


### PR DESCRIPTION
## Summary

Adds `optimizeCloudinaryUrl()` helper that injects Cloudinary transforms into raw API image URLs. Applied to all public pages that render dynamic content:

- **News, Events, PostDetails, EventDetails** pages
- **LatestNewsSection, UpcomingEventsSection** home components
- **Video poster quality** reduced from `q_auto:best` to `q_auto:low` (~111KB → ~40KB)

Images that were being served at full resolution (e.g., 960x720) are now served at display-appropriate sizes (640x480 for cards, 800x600 for detail pages) in WebP/AVIF format.

## Test plan
- [x] Build passes
- [ ] News page images load at proper size
- [ ] Event images load at proper size
- [ ] After deploy: re-run PageSpeed for /news

🤖 Generated with [Claude Code](https://claude.com/claude-code)