### PR TITLE
Eliminate font-swap CLS across all pages

### DIFF
--- a/ppyc_frontend/index.prod.html
+++ b/ppyc_frontend/index.prod.html
@@ -40,14 +40,16 @@
 
     <!-- Preload Critical Assets -->
     <link rel="preload" href="/assets/images/ppyclogo.webp" as="image" type="image/webp" />
+    <link rel="preload" href="/fonts/inter-latin.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/fonts/playfair-latin.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preconnect" href="https://res.cloudinary.com" crossorigin />
 
-    <!-- Inlined font declarations (eliminates extra render-blocking request) -->
+    <!-- Inlined font declarations -->
     <style>
-      @font-face{font-family:'Inter';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/inter-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}
-      @font-face{font-family:'Inter';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/inter-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}
-      @font-face{font-family:'Playfair Display';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/playfair-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}
-      @font-face{font-family:'Playfair Display';font-style:normal;font-weight:400 700;font-display:swap;src:url(/fonts/playfair-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}
+      @font-face{font-family:'Inter';font-style:normal;font-weight:400 700;font-display:optional;src:url(/fonts/inter-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}
+      @font-face{font-family:'Inter';font-style:normal;font-weight:400 700;font-display:optional;src:url(/fonts/inter-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}
+      @font-face{font-family:'Playfair Display';font-style:normal;font-weight:400 700;font-display:optional;src:url(/fonts/playfair-latin.woff2) format('woff2');unicode-range:U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD}
+      @font-face{font-family:'Playfair Display';font-style:normal;font-weight:400 700;font-display:optional;src:url(/fonts/playfair-latin-ext.woff2) format('woff2');unicode-range:U+0100-02BA,U+02BD-02C5,U+02C7-02CC,U+02CE-02D7,U+02DD-02FF,U+0304,U+0308,U+0329,U+1D00-1DBF,U+1E00-1E9F,U+1EF2-1EFF,U+2020,U+20A0-20AB,U+20AD-20C0,U+2113,U+2C60-2C7F,U+A720-A7FF}
     </style>
     
     <title>Pleasant Park Yacht Club</title>


### PR DESCRIPTION
## Summary

Events page had 0.25 CLS from Playfair Display font swap causing heading reflow. This affects all pages with headings. Applied globally via `index.prod.html`:

1. **Preload** `inter-latin.woff2` and `playfair-latin.woff2` — fetched immediately, available before first paint
2. **`font-display: optional`** — if font isn't ready by first paint, browser uses fallback and never swaps (zero CLS)

Since fonts are self-hosted and preloaded, they load in ~50ms and will almost always be ready. On slow connections, the page renders with system fonts with no visual jump.

## Expected impact
- Events CLS: 0.25 → ~0 (affects all pages)
- Events desktop: 86 → 95+ estimated
- Events mobile: 76 → 85+ estimated

## Test plan
- [x] Build passes
- [ ] After deploy: re-run PageSpeed for /events (both mobile and desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)