### PR TITLE
Fix uploaded images not displaying in production

### DIFF
--- a/nginx-ppyc.conf
+++ b/nginx-ppyc.conf
@@ -79,7 +79,8 @@ server {
   }
 
   # Serve uploaded CMS images/videos from Rails public/uploads/
-  location /uploads/ {
+  # ^~ ensures this prefix match takes priority over regex locations for static assets
+  location ^~ /uploads/ {
     alias /var/www/ppyc/ppyc_backend/public/uploads/;
     expires 30d;
     add_header Cache-Control "public";


### PR DESCRIPTION
## Summary
- Uploaded CMS images/videos were not displaying on production because nginx's regex location for static assets (`~* \.(webp|jpg|...)$`) was intercepting `/uploads/*` requests before the `/uploads/` alias location could serve them from the backend's `public/uploads/` directory
- Adding `^~` to the `/uploads/` location gives it priority over regex matches, fixing the issue

## Deploy steps
After merging, on the VPS:
```bash
cd /var/www/ppyc && git pull origin main
sudo cp nginx-ppyc.conf /etc/nginx/sites-enabled/default
sudo nginx -t && sudo systemctl reload nginx
```

## Test plan
- [ ] Upload an image via the CMS admin on production
- [ ] Verify the uploaded image displays correctly on the site
- [ ] Verify existing static assets (fonts, JS, CSS) still load with caching headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)