### PR TITLE
Fix uploaded file permissions for nginx

### DIFF
--- a/ppyc_backend/app/controllers/api/v1/admin/images_controller.rb
+++ b/ppyc_backend/app/controllers/api/v1/admin/images_controller.rb
@@ -36,9 +36,9 @@ class Api::V1::Admin::ImagesController < Api::V1::Admin::BaseController
         return
       end
 
-      # Create folder structure
+      # Create folder structure with world-readable permissions
       upload_folder = UPLOAD_DIR.join(folder)
-      FileUtils.mkdir_p(upload_folder)
+      FileUtils.mkdir_p(upload_folder, mode: 0755)
 
       # Generate unique filename
       ext = File.extname(file.original_filename)
@@ -52,6 +52,7 @@ class Api::V1::Admin::ImagesController < Api::V1::Admin::BaseController
         final_filename = "#{unique_name}#{final_ext}"
         final_path = upload_folder.join(final_filename)
         File.open(final_path, 'wb') { |f| f.write(file.read) }
+        FileUtils.chmod(0644, final_path)
 
         resource_type = 'video'
         width = nil
@@ -74,6 +75,7 @@ class Api::V1::Admin::ImagesController < Api::V1::Admin::BaseController
         final_path = upload_folder.join(final_filename)
         image.format 'webp'
         image.write(final_path)
+        FileUtils.chmod(0644, final_path)
 
         resource_type = 'image'
         width = image.width


### PR DESCRIPTION
## Summary
- Uploaded images had `600` (owner-only) permissions because Puma runs as root
- Nginx runs as `www-data` and couldn't read the files, causing broken image links
- Now sets `644` on uploaded files and `755` on upload directories

## Deploy steps
After merging, on the VPS:
```bash
cd /var/www/ppyc && git pull origin main
cd ppyc_backend && bundle exec pumactl restart

# Fix existing files
chmod -R 644 /var/www/ppyc/ppyc_backend/public/uploads/
find /var/www/ppyc/ppyc_backend/public/uploads/ -type d -exec chmod 755 {} \;
```

## Test plan
- [ ] Fix permissions on existing uploads on VPS
- [ ] Upload a new image via the CMS admin
- [ ] Verify the new image displays in the media library
- [ ] Verify the image displays on the public site (e.g. in a news article)

🤖 Generated with [Claude Code](https://claude.com/claude-code)